### PR TITLE
rrfs_utl: Changes for updating SST for FV3

### DIFF
--- a/update_sst/CMakeLists.txt
+++ b/update_sst/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 
-file(GLOB src_all grib2_read_mod.f90 netCDFsub_geo.f90  process_SST.f90  sstGlobal2RR.f90  update_SST_netcdf_mass.f90)
+### file(GLOB src_all grib2_read_mod.f90 netCDFsub_geo.f90  process_SST.f90  sstGlobal2RR.f90  update_SST_netcdf_mass.f90 update_SST_netcdf_fv3.f90)
+file(GLOB src_all ${CMAKE_CURRENT_SOURCE_DIR}/*.f90)
 set_source_files_properties( ${src_all} PROPERTIES COMPILE_FLAGS ${Fortran_FLAGS} )
 
 include_directories( ${GSIINC} ${G2INC} ${NETCDFINC} )

--- a/update_sst/module_gsi_rfv3io_tten.f90
+++ b/update_sst/module_gsi_rfv3io_tten.f90
@@ -1,0 +1,800 @@
+module gsi_rfv3io_tten_mod
+!$$$   module documentation block
+!             .      .    .                                       .
+! module:     gsi_rfv3io_mod
+!   prgmmr:
+!
+! abstract: IO routines for regional FV3
+!
+  use kinds, only: r_kind,i_kind,r_single
+  use netcdf, only: nf90_write,nf90_inq_varid
+  use netcdf, only: nf90_put_var,nf90_get_var
+  use netcdf, only: nf90_open,nf90_close,nf90_noerr
+  use netcdf, only: nf90_nowrite,nf90_inquire,nf90_inquire_dimension
+  use netcdf, only: nf90_inquire_variable
+  use netcdf, only: nf90_redef,nf90_enddef,nf90_def_var,nf90_put_att
+  use netcdf, only: nf90_noerr,nf90_float
+
+  implicit none
+  integer(i_kind) nx,ny,nz 
+  integer(i_kind) lat2,lon2,nsig
+  integer(i_kind) nlon_regional,nlat_regional,nsig_regional
+ 
+  real,parameter :: grav=9.8
+  integer,parameter :: rfv3io_mype=0
+
+!    directory names (hardwired for now)
+  type type_fv3regfilenameg
+      character(len=:),allocatable :: grid_spec !='fv3_grid_spec'            
+      character(len=:),allocatable :: ak_bk     !='fv3_akbk'
+      character(len=:),allocatable :: dynvars   !='fv3_dynvars'
+      character(len=:),allocatable :: tracers   !='fv3_tracer'
+      character(len=:),allocatable :: sfcdata   !='fv3_sfcdata'
+      character(len=:),allocatable :: phydata   !='fv3_phydata'
+      character(len=:),allocatable :: couplerres!='coupler.res'
+      contains
+      procedure , pass(this):: init=>fv3regfilename_init
+  end type type_fv3regfilenameg
+
+  integer(i_kind):: fv3sar_bg_opt=0
+  type(type_fv3regfilenameg):: bg_fv3regfilenameg
+
+
+! set default to private
+  private
+! set subroutines to public
+  public :: nlon_regional,nlat_regional,nsig_regional
+  public :: gsi_rfv3io_get_grid_specs
+  public :: type_fv3regfilenameg
+  public :: bg_fv3regfilenameg
+  public :: fv3sar_bg_opt
+  public :: rfv3io_mype
+
+
+  public :: gsi_fv3ncdf_read
+  public :: gsi_fv3ncdf2d_read
+  public :: gsi_fv3ncdf_write
+  public :: gsi_fv3ncdf_append
+  public :: gsi_fv3ncdf_append2d
+
+  public :: aeta1_ll,aeta2_ll
+  public :: eta1_ll,eta2_ll
+
+  real(r_kind),allocatable :: aeta1_ll(:),aeta2_ll(:)
+  real(r_kind),allocatable :: eta1_ll(:),eta2_ll(:)
+
+contains
+
+  subroutine fv3regfilename_init(this,grid_spec_input,ak_bk_input,dynvars_input,&
+                      tracers_input,sfcdata_input,phydata_input,couplerres_input)
+  implicit None
+  class(type_fv3regfilenameg),intent(inout):: this
+
+  character(*),optional :: grid_spec_input,ak_bk_input,dynvars_input, &
+                      tracers_input,sfcdata_input,phydata_input,couplerres_input
+
+  if(present(grid_spec_input))then
+    this%grid_spec=grid_spec_input
+  else
+    this%grid_spec='fv3_grid_spec'
+  endif
+
+  if(present(ak_bk_input))then
+    this%ak_bk=ak_bk_input
+  else
+    this%ak_bk='fv3_akbk'
+  endif
+
+  if(present(dynvars_input))then
+    this%dynvars=dynvars_input
+  else
+    this%dynvars='fv3_dynvars'
+  endif
+
+  if(present(tracers_input))then
+    this%tracers=tracers_input
+  else
+    this%tracers='fv3_tracer'
+  endif
+
+  if(present(sfcdata_input))then
+    this%sfcdata=sfcdata_input
+  else
+    this%sfcdata='fv3_sfcdata'
+  endif
+
+  if(present(phydata_input))then
+    this%phydata=phydata_input
+  else
+    this%phydata='fv3_phydata'
+  endif
+
+  if(present(couplerres_input))then
+    this%couplerres=couplerres_input
+  else
+    this%couplerres='coupler.res'
+  endif
+
+  end subroutine fv3regfilename_init
+
+subroutine gsi_rfv3io_get_grid_specs(fv3filenamegin,ierr)
+
+
+  implicit none
+  integer(i_kind),intent(  out) :: ierr
+  type (type_fv3regfilenameg),intent(in) :: fv3filenamegin
+
+  integer(i_kind) gfile_grid_spec
+
+  character(len=:),allocatable    :: grid_spec
+  character(len=:),allocatable    :: ak_bk
+  integer(i_kind) i,k,ndimensions,iret,nvariables,nattributes,unlimiteddimid
+  integer(i_kind) len,gfile_loc
+  character(len=128) :: name
+
+  real(r_kind),allocatable :: ak(:),bk(:),abk_fv3(:)
+
+  grid_spec=fv3filenamegin%grid_spec
+  ak_bk=fv3filenamegin%ak_bk
+!!!!!!!!!!    grid_spec  !!!!!!!!!!!!!!!
+    ierr=0
+    iret=nf90_open(trim(grid_spec),nf90_nowrite,gfile_grid_spec)
+    if(iret/=nf90_noerr) then
+       write(6,*)' gsi_rfv3io_get_grid_specs: problem opening', &
+                   trim(grid_spec),', Status = ',iret
+       ierr=1
+       return
+    endif
+
+    iret=nf90_inquire(gfile_grid_spec,ndimensions,nvariables,nattributes,unlimiteddimid)
+    gfile_loc=gfile_grid_spec
+    do k=1,ndimensions
+       iret=nf90_inquire_dimension(gfile_loc,k,name,len)
+       if(trim(name)=='grid_xt') nx=len
+       if(trim(name)=='grid_yt') ny=len
+    enddo
+    nlon_regional=nx
+    nlat_regional=ny
+    lat2=ny
+    lon2=nx
+    if(rfv3io_mype==0)write(6,*),'nx,ny=',nx,ny
+
+!!!    get nx,ny,grid_lon,grid_lont,grid_lat,grid_latt,nz,ak,bk
+
+    iret=nf90_open(trim(ak_bk),nf90_nowrite,gfile_loc)
+    if(iret/=nf90_noerr) then
+       write(6,*)'gsi_rfv3io_get_grid_specs: problem opening ', &
+                 trim(ak_bk),',Status = ',iret
+       ierr=1
+       return
+    endif
+    iret=nf90_inquire(gfile_loc,ndimensions,nvariables,nattributes,unlimiteddimid)
+    do k=1,ndimensions
+       iret=nf90_inquire_dimension(gfile_loc,k,name,len)
+       if(trim(name)=='xaxis_1') nz=len
+    enddo
+    if(rfv3io_mype==0)write(6,'(" nz=",i5)') nz
+
+    nsig=nz-1
+    nsig_regional=nz-1
+
+!!!    get ak,bk
+
+    allocate(aeta1_ll(nsig),aeta2_ll(nsig))
+    allocate(eta1_ll(nsig+1),eta2_ll(nsig+1))
+    allocate(ak(nz),bk(nz),abk_fv3(nz))
+
+
+    do k=ndimensions+1,nvariables
+       iret=nf90_inquire_variable(gfile_loc,k,name,len)
+       if(trim(name)=='ak'.or.trim(name)=='AK') then
+          iret=nf90_get_var(gfile_loc,k,abk_fv3)
+          do i=1,nz
+             ak(i)=abk_fv3(nz+1-i)
+          enddo
+       endif
+       if(trim(name)=='bk'.or.trim(name)=='BK') then
+          iret=nf90_get_var(gfile_loc,k,abk_fv3)
+          do i=1,nz
+             bk(i)=abk_fv3(nz+1-i)
+          enddo
+       endif
+    enddo
+    iret=nf90_close(gfile_loc)
+
+!!!!! change unit of ak 
+    do i=1,nsig+1
+       eta1_ll(i)=ak(i)*0.001_r_kind
+       eta2_ll(i)=bk(i)
+    enddo
+    do i=1,nsig
+       aeta1_ll(i)=0.5_r_kind*(ak(i)+ak(i+1))*0.001_r_kind
+       aeta2_ll(i)=0.5_r_kind*(bk(i)+bk(i+1))
+    enddo
+    if(rfv3io_mype==0)then
+       do i=1,nz
+          write(6,'(" ak,bk(",i3,") = ",2f17.6)') i,ak(i),bk(i)
+       enddo
+    endif
+
+
+    deallocate (ak,bk,abk_fv3)
+
+    return
+end subroutine gsi_rfv3io_get_grid_specs
+
+subroutine gsi_fv3ncdf2d_read(filenamein,varname,varname2,work_sub,mype_io)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    gsi_fv3ncdf2d_read       
+!   prgmmr: wu w             org: np22                date: 2017-10-17
+!
+! abstract: read in 2d fields from fv3_sfcdata file in mype_2d 
+!                Scatter the field to each PE 
+! program history log:
+!   input argument list:
+!     it    - time index for 2d fields
+!
+!   output argument list:
+!     ges_z - surface elevation
+!
+! attributes:
+!   language: f90
+!   machine:  ibm RS/6000 SP
+!
+!$$$  end documentation block
+
+    implicit none
+
+    character(*)     ,intent(in   ) :: varname,varname2,filenamein
+    real(r_single)   ,intent(out  ) :: work_sub(lon2,lat2) 
+    integer(i_kind)  ,intent(in   ) :: mype_io
+
+    character(len=128) :: name
+    real(r_kind),allocatable,dimension(:,:)   :: f2d
+    integer(i_kind),allocatable,dimension(:)  :: dim_id,dim
+
+    integer(i_kind) iret,gfile_loc,i,k,len,ndim
+    integer(i_kind) ndimensions,nvariables,nattributes,unlimiteddimid
+   
+    if(rfv3io_mype == mype_io) then
+
+       work_sub=-99999.0
+
+       iret=nf90_open(filenamein,nf90_nowrite,gfile_loc)
+       if(iret/=nf90_noerr) then
+          write(6,*)' problem opening3 ',trim(filenamein),', Status = ',iret
+          return
+       endif
+
+       iret=nf90_inquire(gfile_loc,ndimensions,nvariables,nattributes,unlimiteddimid)
+       allocate(dim(ndimensions))
+       do k=1,ndimensions
+          iret=nf90_inquire_dimension(gfile_loc,k,name,len)
+          dim(k)=len
+       enddo
+       !write(*,*) ndimensions,nvariables,nattributes,unlimiteddimid
+
+       do i=1,nvariables
+          iret=nf90_inquire_variable(gfile_loc,i,name,len)
+          if( trim(name)==varname.or.trim(name)==varname2 ) then
+             iret=nf90_inquire_variable(gfile_loc,i,ndims=ndim)
+             if(allocated(dim_id    )) deallocate(dim_id    )
+             allocate(dim_id(ndim))
+             iret=nf90_inquire_variable(gfile_loc,i,dimids=dim_id)
+             !write(*,*) trim(name),ndim,dim_id
+
+             if(allocated(f2d       )) deallocate(f2d       )
+             if(ndim==2) then
+                allocate(f2d(dim(dim_id(1)),dim(dim_id(2))))
+             elseif(ndim==3 .and. dim(dim_id(3))==1) then
+                allocate(f2d(dim(dim_id(1)),dim(dim_id(2))))
+             else
+                write(6,*) 'unknow dimension szie=',ndim
+             endif
+
+             iret=nf90_get_var(gfile_loc,i,f2d)
+
+             if(lon2==dim(dim_id(1)) .and. lat2==dim(dim_id(2))) then
+                work_sub(:,:)=f2d(:,:)
+             else
+                write(6,*) 'horizontal mismatch=',lon2,lat2
+                write(6,*) 'dimension reads in=',dim(dim_id(1)),dim(dim_id(2))
+                stop 123
+             endif
+             deallocate (f2d)
+
+             deallocate (dim_id,dim)
+             exit
+          endif
+       enddo ! i
+       iret=nf90_close(gfile_loc)
+
+    endif  ! mype
+
+    return
+end subroutine gsi_fv3ncdf2d_read
+
+subroutine gsi_fv3ncdf_read(filenamein,varname,varname2,work_sub,mype_io)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    gsi_fv3ncdf_read       
+!   prgmmr: wu               org: np22                date: 2017-10-10
+!
+! abstract: read in a field from a netcdf FV3 file in mype_io
+!          then scatter the field to each PE 
+! program history log:
+!
+!   input argument list:
+!     filename    - file name to read from       
+!     varname     - variable name to read in
+!     varname2    - variable name to read in
+!     mype_io     - pe to read in the field
+!
+!   output argument list:
+!     work_sub    - output sub domain field
+!
+! attributes:
+!   language: f90
+!   machine:  ibm RS/6000 SP
+!
+!$$$  end documentation block
+
+
+    implicit none
+    integer(i_kind), parameter :: nsig=9
+    character(*)      ,intent(in   ) :: varname,varname2,filenamein
+    real(r_single)    ,intent(out  ) :: work_sub(lon2,lat2,nsig) 
+    integer(i_kind)   ,intent(in   ) :: mype_io
+
+    character(len=128)                          :: name
+    real(r_kind),allocatable,dimension(:,:,:)   :: f3d
+    integer(i_kind),allocatable,dimension(:)    :: dim_id,dim
+
+    integer(i_kind) n,ns,k,len,ndim
+    integer(i_kind) gfile_loc,iret
+    integer(i_kind) kk
+    integer(i_kind) ndimensions,nvariables,nattributes,unlimiteddimid
+
+    write(*,*)'rfv3io_mype:',rfv3io_mype
+    if(rfv3io_mype==mype_io ) then
+    write(*,*)'mype_io 1:',mype_io
+   !    work_sub=-99999.0
+    write(*,*)'mype_io 2:',mype_io
+
+       iret=nf90_open(trim(filenamein),nf90_nowrite,gfile_loc)
+       if(iret/=nf90_noerr) then
+          write(6,*)' gsi_fv3ncdf_read: problem opening ',trim(filenamein),gfile_loc,', Status = ',iret
+          write(6,*)' gsi_fv3ncdf_read:problem opening5 with varnam ',trim(varname)
+          return
+       endif
+
+       iret=nf90_inquire(gfile_loc,ndimensions,nvariables,nattributes,unlimiteddimid)
+                write(*,*)'ndimsiona:', ndimensions
+       allocate(dim(ndimensions))
+
+       do k=1,ndimensions
+          iret=nf90_inquire_dimension(gfile_loc,k,name,len)
+          dim(k)=len
+       enddo
+
+       do k=1,nvariables
+          iret=nf90_inquire_variable(gfile_loc,k,name,len)
+          write(*,*) k,trim(name),varname,varname2
+          if(trim(name)==varname .or. trim(name)==varname2) then
+             iret=nf90_inquire_variable(gfile_loc,k,ndims=ndim)
+             if(allocated(dim_id    )) deallocate(dim_id    )
+             allocate(dim_id(ndim))
+             iret=nf90_inquire_variable(gfile_loc,k,dimids=dim_id)
+             write(*,*) trim(name),ndim,dim_id
+
+             if(ndim==3) then
+                write(*,*)'ndim:', ndim
+                if(allocated(f3d        )) deallocate(f3d        )
+                allocate(f3d(dim(dim_id(1)),dim(dim_id(2)),dim(dim_id(3))))
+             elseif(ndim==4 .and. dim(dim_id(4))==1) then
+                write(*,*)'ndim:', ndim
+                if(allocated(f3d        )) deallocate(f3d        )
+                allocate(f3d(dim(dim_id(1)),dim(dim_id(2)),dim(dim_id(3))))
+             else
+                write(6,*) 'unknow dimension szie=',ndim
+             endif
+
+             iret=nf90_get_var(gfile_loc,k,f3d)
+             !do kk=1,dim(dim_id(3))
+             !   write(6,*) kk,maxval(f3d(:,:,kk)),minval(f3d(:,:,kk))
+             !enddo
+
+             if(lon2==dim(dim_id(1)) .and. lat2==dim(dim_id(2))) then
+                write(*,*)'nsig,dim(dim_id(3))', nsig,dim(dim_id(3))
+                if(nsig == dim(dim_id(3))) then
+                   do kk=1,nsig
+                     work_sub(:,:,kk)=f3d(:,:,nsig-kk+1)
+                   enddo
+                elseif(nsig+1== dim(dim_id(3))) then
+                   do kk=1,nsig
+                     work_sub(:,:,kk)=f3d(:,:,nsig+1-kk+1)
+                   enddo
+                elseif(nsig+2==dim(dim_id(3)) .and. trim(name)=='zh') then
+                   do kk=1,nsig
+                     work_sub(:,:,kk)=( f3d(:,:,nsig+2-kk+1)+ &
+                                        f3d(:,:,nsig+2-kk) )*0.5_r_kind
+                   enddo
+                else
+                   write(6,*) 'vertical mismatch=',nsig,nsig+1
+                   write(6,*) 'dimension reads in=',dim(dim_id(3))
+                   stop 123
+                endif
+             else
+                write(6,*) 'horizontal mismatch=',lon2,lat2
+                write(6,*) 'dimension reads in=',dim(dim_id(1)),dim(dim_id(2))
+                stop 123
+             endif
+
+             deallocate (f3d,dim,dim_id)
+             exit
+          endif
+       enddo     !   k
+       iret=nf90_close(gfile_loc)
+
+    endif !mype
+
+    return
+end subroutine gsi_fv3ncdf_read
+
+subroutine gsi_fv3ncdf_write(filename,varname,var,mype_io)
+!$$$  subprogram documentation block
+!                .      .    .                                        .
+! subprogram:    gsi_nemsio_write
+!   pgrmmr: wu
+!
+! abstract:
+!
+! program history log:
+!
+!   input argument list:
+!    varu,varv
+!    add_saved
+!    mype     - mpi task id
+!    mype_io
+!
+!   output argument list:
+!
+! attributes:
+!   language: f90
+!   machine:
+!
+!$$$ end documentation block
+
+    implicit none
+
+    real(r_single)   ,intent(in   ) :: var(lon2,lat2,nsig)
+    integer(i_kind),intent(in   ) :: mype_io
+    character(*)   ,intent(in   ) :: varname,filename
+
+    integer(i_kind) :: VarId,gfile_loc
+    integer(i_kind),allocatable,dimension(:)    :: dim_id,dim
+    character(len=128)                          :: name
+    integer(i_kind) iret,k,kk,len,ndim
+    integer(i_kind) ndimensions,nvariables,nattributes,unlimiteddimid
+
+    real(r_kind),allocatable,dimension(:,:,:)   :: f3d
+
+    if(rfv3io_mype==mype_io) then
+
+       call check( nf90_open(trim(filename),nf90_write,gfile_loc) )
+
+       iret=nf90_inquire(gfile_loc,ndimensions,nvariables,nattributes,unlimiteddimid)
+       allocate(dim(ndimensions))
+
+       do k=1,ndimensions
+          iret=nf90_inquire_dimension(gfile_loc,k,name,len)
+          dim(k)=len
+       enddo
+
+       call check( nf90_inq_varid(gfile_loc,trim(varname),VarId) )
+
+       iret=nf90_inquire_variable(gfile_loc,VarId,ndims=ndim)
+       if(allocated(dim_id    )) deallocate(dim_id    )
+       allocate(dim_id(ndim))
+       iret=nf90_inquire_variable(gfile_loc,VarId,dimids=dim_id)
+
+       if(ndim==3 .or. (ndim==4 .and. dim(dim_id(4))==1) ) then
+          if(allocated(f3d        )) deallocate(f3d        )
+          allocate(f3d(dim(dim_id(1)),dim(dim_id(2)),dim(dim_id(3))))
+
+          if(lon2==dim(dim_id(1)) .and. lat2==dim(dim_id(2))) then
+             if(nsig == dim(dim_id(3))) then
+                do kk=1,nsig
+                   f3d(:,:,nsig-kk+1)=var(:,:,kk)
+                enddo
+             elseif(nsig+1== dim(dim_id(3))) then
+                do kk=1,nsig
+                  f3d(:,:,nsig+1-kk+1)=var(:,:,kk)
+                enddo
+                f3d(:,:,1)=var(:,:,nsig)
+             else
+                write(6,*) 'vertical mismatch=',nsig,nsig+1
+                write(6,*) 'dimension reads in=',dim(dim_id(3))
+                stop 123
+             endif
+          else
+             write(6,*) 'horizontal mismatch=',lon2,lat2
+             write(6,*) 'dimension reads in=',dim(dim_id(1)),dim(dim_id(2))
+             stop 123
+          endif
+       else
+          write(6,*) 'unknow dimension szie=',ndim
+       endif
+
+       print *,'write out ',trim(varname),' to ',trim(filename)
+       call check( nf90_put_var(gfile_loc,VarId,f3d) )
+       call check( nf90_close(gfile_loc) )
+    end if !mype_io
+
+end subroutine gsi_fv3ncdf_write
+
+subroutine gsi_fv3ncdf_append(filename,varname,var,mype_io)
+!$$$  subprogram documentation block
+!                .      .    .                                        .
+! subprogram:    gsi_nemsio_write
+!   pgrmmr: wu
+!
+! abstract:
+!
+! program history log:
+!
+!   input argument list:
+!    varu,varv
+!    add_saved
+!    mype     - mpi task id
+!    mype_io
+!
+!   output argument list:
+!
+! attributes:
+!   language: f90
+!   machine:
+!
+!$$$ end documentation block
+
+    implicit none
+
+    real(r_single)   ,intent(in   ) :: var(lon2,lat2,nsig)
+    integer(i_kind),intent(in   ) :: mype_io
+    character(*)   ,intent(in   ) :: varname,filename
+
+    integer(i_kind) :: VarId,gfile_loc
+    integer(i_kind),allocatable,dimension(:)    :: dim_id,dim
+    character(len=128)                          :: name
+    character(len=128),allocatable,dimension(:) :: dim_names
+    integer(i_kind) iret,k,kk,len,ndim
+    integer(i_kind) ndimensions,nvariables,nattributes,unlimiteddimid
+
+    real(r_kind),allocatable,dimension(:,:,:)   :: f3d
+
+    if(rfv3io_mype==mype_io) then
+
+       call check( nf90_open(trim(filename),nf90_write,gfile_loc) )
+
+       iret=nf90_inquire(gfile_loc,ndimensions,nvariables,nattributes,unlimiteddimid)
+       allocate(dim(ndimensions))
+       allocate(dim_names(ndimensions))
+
+       do k=1,ndimensions
+          iret=nf90_inquire_dimension(gfile_loc,k,name,len)
+          dim(k)=len
+          dim_names(k)=name
+          write(*,*) 'dimension=',k,len,name
+       enddo
+
+       iret=nf90_inq_varid(gfile_loc,trim(varname),VarId)
+       if(iret == nf90_NoErr) then
+          iret=nf90_inquire_variable(gfile_loc,VarId,ndims=ndim)
+          if(allocated(dim_id    )) deallocate(dim_id    )
+          allocate(dim_id(ndim))
+          iret=nf90_inquire_variable(gfile_loc,VarId,dimids=dim_id)
+          write(*,*) 'check dimension=',ndim,dim_id
+          print *,'update ',trim(varname),' to ',trim(filename)
+       else ! add a varaible
+          call check( nf90_redef(gfile_loc))
+          if(allocated(dim_id    )) deallocate(dim_id    )
+          if(trim(dim_names(1))=='lon') then
+             ndim=3
+             allocate(dim_id(ndim))
+             dim_id(1)=1
+             dim_id(2)=2
+             dim_id(3)=5
+             call check( nf90_def_var(gfile_loc,trim(varname),nf90_float,(/ dim_id(1), dim_id(2), dim_id(3) /),VarId))
+          else
+             ndim=4
+             allocate(dim_id(ndim))
+             dim_id(1)=1
+             dim_id(2)=2
+             dim_id(3)=3
+             dim_id(4)=4
+             call check( nf90_def_var(gfile_loc,trim(varname),nf90_float,(/ dim_id(1), dim_id(2), dim_id(3), dim_id(4) /),VarId))
+          endif
+          call check( nf90_put_att(gfile_loc, VarId, "long_name",  &
+                         "temperature tendency from reflectivity"))
+          call check( nf90_put_att(gfile_loc, VarId, "units", "k s-1"))
+          call check( nf90_enddef(gfile_loc))
+          print *,'add ',trim(varname),' to ',trim(filename)
+       endif
+
+       if(ndim==3 .or. (ndim==4 .and. dim(dim_id(4))==1) ) then
+          if(allocated(f3d        )) deallocate(f3d        )
+          allocate(f3d(dim(dim_id(1)),dim(dim_id(2)),dim(dim_id(3))))
+
+          if(lon2==dim(dim_id(1)) .and. lat2==dim(dim_id(2))) then
+             if(nsig == dim(dim_id(3))) then
+                do kk=1,nsig
+                   f3d(:,:,nsig-kk+1)=var(:,:,kk)
+                enddo
+             elseif(nsig+1== dim(dim_id(3))) then
+                do kk=1,nsig
+                  f3d(:,:,nsig+1-kk+1)=var(:,:,kk)
+                enddo
+                f3d(:,:,1)=var(:,:,nsig)
+             else
+                write(6,*) 'vertical mismatch=',nsig,nsig+1
+                write(6,*) 'dimension reads in=',dim(dim_id(3))
+                stop 123
+             endif
+          else
+             write(6,*) 'horizontal mismatch=',lon2,lat2
+             write(6,*) 'dimension reads in=',dim(dim_id(1)),dim(dim_id(2))
+             stop 123
+          endif
+       else
+          write(6,*) 'unknow dimension size=',ndim
+       endif
+       print *,'write ',trim(varname),' to ',trim(filename)
+
+       call check( nf90_put_var(gfile_loc,VarId,f3d) )
+       call check( nf90_close(gfile_loc) )
+    end if !mype_io
+
+end subroutine gsi_fv3ncdf_append
+
+subroutine gsi_fv3ncdf_append2d(filename,varname,var,mype_io)
+!$$$  subprogram documentation block
+!                .      .    .                                        .
+! subprogram:    gsi_nemsio_write
+!   pgrmmr: wu
+!
+! abstract:
+!
+! program history log:
+!
+!   input argument list:
+!    varu,varv
+!    add_saved
+!    mype     - mpi task id
+!    mype_io
+!
+!   output argument list:
+!
+! attributes:
+!   language: f90
+!   machine:
+!
+!$$$ end documentation block
+
+    implicit none
+
+    real(r_single)   ,intent(in   ) :: var(lon2,lat2)
+    integer(i_kind),intent(in   ) :: mype_io
+    character(*)   ,intent(in   ) :: varname,filename
+
+    integer(i_kind) :: VarId,gfile_loc
+    integer(i_kind),allocatable,dimension(:)    :: dim_id,dim
+    character(len=128)                          :: name
+    character(len=128),allocatable,dimension(:) :: dim_names
+    integer(i_kind) iret,k,kk,len,ndim
+    integer(i_kind) ndimensions,nvariables,nattributes,unlimiteddimid
+
+  !  real(r_kind),allocatable,dimension(:,:,:)   :: f3d
+    real(r_kind),allocatable,dimension(:,:)   :: f2d
+
+    if(rfv3io_mype==mype_io) then
+
+       call check( nf90_open(trim(filename),nf90_write,gfile_loc) )
+
+       iret=nf90_inquire(gfile_loc,ndimensions,nvariables,nattributes,unlimiteddimid)
+       allocate(dim(ndimensions))
+       allocate(dim_names(ndimensions))
+
+       do k=1,ndimensions
+          iret=nf90_inquire_dimension(gfile_loc,k,name,len)
+          dim(k)=len
+          dim_names(k)=name
+          write(*,*) 'dimension=',k,len,name
+       enddo
+
+       iret=nf90_inq_varid(gfile_loc,trim(varname),VarId)
+       if(iret == nf90_NoErr) then
+          iret=nf90_inquire_variable(gfile_loc,VarId,ndims=ndim)
+          if(allocated(dim_id    )) deallocate(dim_id    )
+          allocate(dim_id(ndim))
+          iret=nf90_inquire_variable(gfile_loc,VarId,dimids=dim_id)
+          write(*,*) 'check dimension=',ndim,dim_id
+          print *,'update ',trim(varname),' to ',trim(filename)
+       else ! add a varaible
+          call check( nf90_redef(gfile_loc))
+          if(allocated(dim_id    )) deallocate(dim_id    )
+          if(trim(dim_names(1))=='lon') then
+             ndim=3
+             allocate(dim_id(ndim))
+             dim_id(1)=1
+             dim_id(2)=2
+             dim_id(3)=5
+             call check( nf90_def_var(gfile_loc,trim(varname),nf90_float,(/ dim_id(1), dim_id(2), dim_id(3) /),VarId))
+          else
+             ndim=4
+             allocate(dim_id(ndim))
+             dim_id(1)=1
+             dim_id(2)=2
+             dim_id(3)=3
+             dim_id(4)=4
+             call check( nf90_def_var(gfile_loc,trim(varname),nf90_float,(/ dim_id(1), dim_id(2), dim_id(3), dim_id(4) /),VarId))
+          endif
+          call check( nf90_put_att(gfile_loc, VarId, "long_name",  &
+                         "temperature tendency from reflectivity"))
+          call check( nf90_put_att(gfile_loc, VarId, "units", "k s-1"))
+          call check( nf90_enddef(gfile_loc))
+          print *,'add ',trim(varname),' to ',trim(filename)
+       endif
+
+       if(ndim==3 .or. (ndim==4 .and. dim(dim_id(4))==1) ) then
+  !        if(allocated(f3d        )) deallocate(f3d        )
+          if(allocated(f2d        )) deallocate(f2d        )
+  !        allocate(f3d(dim(dim_id(1)),dim(dim_id(2)),dim(dim_id(3))))
+          allocate(f2d(dim(dim_id(1)),dim(dim_id(2))))
+
+          if(lon2==dim(dim_id(1)) .and. lat2==dim(dim_id(2))) then
+  !           if(nsig == dim(dim_id(3))) then
+  !              do kk=1,nsig
+  !                 f3d(:,:,nsig-kk+1)=var(:,:,kk)
+  !              enddo
+  !           elseif(nsig+1== dim(dim_id(3))) then
+  !              do kk=1,nsig
+  !                f3d(:,:,nsig+1-kk+1)=var(:,:,kk)
+  !              enddo
+  !              f3d(:,:,1)=var(:,:,nsig)
+  !           else
+  !              write(6,*) 'vertical mismatch=',nsig,nsig+1
+  !              write(6,*) 'dimension reads in=',dim(dim_id(3))
+  !              write(6,*)' deal with 2d variable '
+                f2d(:,:)=var(:,:)
+!                stop 123
+ !            endif
+          else
+             write(6,*) 'horizontal mismatch=',lon2,lat2
+             write(6,*) 'dimension reads in=',dim(dim_id(1)),dim(dim_id(2))
+             stop 123
+          endif
+       else
+          write(6,*) 'unknow dimension size=',ndim
+       endif
+       print *,'write ',trim(varname),' to ',trim(filename)
+
+!       call check( nf90_put_var(gfile_loc,VarId,f3d) )
+       call check( nf90_put_var(gfile_loc,VarId,f2d) )
+       call check( nf90_close(gfile_loc) )
+    end if !mype_io
+
+end subroutine gsi_fv3ncdf_append2d
+
+subroutine check(status)
+    use kinds, only: i_kind
+    use netcdf, only: nf90_noerr,nf90_strerror
+    integer(i_kind), intent ( in) :: status
+
+    if(status /= nf90_noerr) then
+       print *,'ncdf error ', trim(nf90_strerror(status))
+       stop  
+    end if
+end subroutine check
+
+end module gsi_rfv3io_tten_mod

--- a/update_sst/netCDFsub_geo.f90
+++ b/update_sst/netCDFsub_geo.f90
@@ -31,7 +31,7 @@ Subroutine  CLOSE_geo(NCID)
 end Subroutine CLOSE_geo
 
 
-Subroutine  GET_geo_sngl_geo(NCID,mscNlon,mscNlat,mscValueLAT,mscValueLON,mscValueLand,mscValueLanduse)
+Subroutine  GET_geo_sngl_geo(NCID,mscNlon,mscNlat,mscValueLAT,mscValueLON)
 !
 !  Author: Ming Hu, ESRL/GSD
 !  
@@ -44,7 +44,6 @@ Subroutine  GET_geo_sngl_geo(NCID,mscNlon,mscNlat,mscValueLAT,mscValueLON,mscVal
 !  out:
 !     mscValueLAT
 !     mscValueLON
-!     mscValueLand
 !
   IMPLICIT NONE
 
@@ -53,7 +52,7 @@ Subroutine  GET_geo_sngl_geo(NCID,mscNlon,mscNlat,mscValueLAT,mscValueLON,mscVal
   INTEGER ::   mscNlon   ! number of longitude of mosaic data
   INTEGER ::   mscNlat   ! number of latitude of mosaic data
 
-  INTEGER ::  NCID, STATUS, MSLATID,MSLONID,MSLANDID
+  INTEGER ::  NCID, STATUS, MSLATID,MSLONID
 
   INTEGER ::   NDIMS
   PARAMETER (NDIMS=3)                  ! number of dimensions
@@ -61,8 +60,6 @@ Subroutine  GET_geo_sngl_geo(NCID,mscNlon,mscNlat,mscValueLAT,mscValueLON,mscVal
 
   REAL ::   mscValueLAT(mscNlon,mscNlat,1)
   REAL ::   mscValueLON(mscNlon,mscNlat,1)
-  REAL ::   mscValueLand(mscNlon,mscNlat,1)
-  REAL ::   mscValueLanduse(mscNlon,mscNlat,1)
   INTEGER :: i,j
 
   START(1)=1
@@ -80,16 +77,6 @@ Subroutine  GET_geo_sngl_geo(NCID,mscNlon,mscNlat,mscValueLAT,mscValueLON,mscVal
   STATUS = NF_INQ_VARID (NCID, 'XLONG_M', MSLONID)
   IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR_geo(STATUS)
   STATUS = NF_GET_VARA_REAL (NCID, MSLONID, START, COUNT, mscValueLON)
-  IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR_geo(STATUS)
-
-  STATUS = NF_INQ_VARID (NCID, 'LANDMASK', MSLANDID)
-  IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR_geo(STATUS)
-  STATUS = NF_GET_VARA_REAL (NCID, MSLANDID, START, COUNT, mscValueLand)
-  IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR_geo(STATUS)
-
-  STATUS = NF_INQ_VARID (NCID, 'LU_INDEX', MSLANDID)
-  IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR_geo(STATUS)
-  STATUS = NF_GET_VARA_REAL (NCID, MSLANDID, START, COUNT, mscValueLanduse)
   IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR_geo(STATUS)
 
 end subroutine GET_geo_sngl_geo
@@ -147,3 +134,195 @@ SUBROUTINE HANDLE_ERR_geo(STATUS)
        STOP 'Stopped'
      ENDIF
 END SUBROUTINE HANDLE_ERR_geo
+
+Subroutine  GET_DIM_ATT_fv3sar(geosngle,LONLEN,LATLEN)
+!
+!  Author: Ming Hu, GSL.
+!  
+!  First written: 04/06/2019.
+!
+!  IN:
+!     geosngle : name of mosaic file
+!  OUT
+!     LONLEN
+!     LATLEN
+!
+  IMPLICIT NONE
+
+  INCLUDE 'netcdf.inc'
+
+  CHARACTER*120    geosngle
+
+  INTEGER ::   mscNlon   ! number of longitude of mosaic data
+  INTEGER ::   mscNlat   ! number of latitude of mosaic data
+
+  INTEGER ::  NCID, STATUS
+  INTEGER ::  LONID, LATID
+  INTEGER ::  LONLEN, LATLEN
+
+  STATUS = NF_OPEN(trim(geosngle), 0, NCID)
+  IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR_geo(STATUS)
+
+  STATUS = NF_INQ_DIMID(NCID, 'grid_xt', LONID)
+  IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR_geo(STATUS)
+  STATUS = NF_INQ_DIMID(NCID, 'grid_yt', LATID)
+  IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR_geo(STATUS)
+
+  STATUS = NF_INQ_DIMLEN(NCID, LONID, LONLEN)
+  IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR_geo(STATUS)
+  STATUS = NF_INQ_DIMLEN(NCID, LATID, LATLEN)
+  IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR_geo(STATUS)
+
+  STATUS = NF_CLOSE(NCID)
+  IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR_geo(STATUS) 
+
+END SUBROUTINE GET_DIM_ATT_fv3sar
+
+Subroutine  GET_DIM_ATT_fv3sar_sfcdata(geosngle,LONLEN,LATLEN,LEVLEN)
+!
+!  Author: Ming Hu, GSL.
+!  
+!  First written: 04/06/2019.
+!
+!  IN:
+!     geosngle : name of mosaic file
+!  OUT
+!     LONLEN
+!     LATLEN
+!     LEVLEN
+!
+  IMPLICIT NONE
+
+  INCLUDE 'netcdf.inc'
+
+  CHARACTER*120    geosngle
+
+  INTEGER ::   mscNlon   ! number of longitude of mosaic data
+  INTEGER ::   mscNlat   ! number of latitude of mosaic data
+  INTEGER ::   mscNlev   ! number of latitude of mosaic data
+
+  INTEGER ::  NCID, STATUS
+  INTEGER ::  LONID, LATID, LEVID
+  INTEGER ::  LONLEN, LATLEN, LEVLEN
+
+  STATUS = NF_OPEN(trim(geosngle), 0, NCID)
+  IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR_geo(STATUS)
+
+  STATUS = NF_INQ_DIMID(NCID, 'xaxis_1', LONID)
+  IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR_geo(STATUS)
+  STATUS = NF_INQ_DIMID(NCID, 'yaxis_1', LATID)
+  IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR_geo(STATUS)
+  STATUS = NF_INQ_DIMID(NCID, 'zaxis_1', LEVID)
+  IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR_geo(STATUS)
+
+  STATUS = NF_INQ_DIMLEN(NCID, LONID, LONLEN)
+  IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR_geo(STATUS)
+  STATUS = NF_INQ_DIMLEN(NCID, LATID, LATLEN)
+  IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR_geo(STATUS)
+  STATUS = NF_INQ_DIMLEN(NCID, LEVID, LEVLEN)
+  IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR_geo(STATUS)
+
+  STATUS = NF_CLOSE(NCID)
+  IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR_geo(STATUS) 
+
+END SUBROUTINE GET_DIM_ATT_fv3sar_sfcdata
+
+Subroutine  GET_geo_sngl_fv3sar(NCID,mscNlon,mscNlat,mscValueLAT,mscValueLON)
+!
+!  Author: Ming Hu, ESRL/GSD
+!  
+!  First written: 12/16/2007.
+!
+!  IN:
+!     mscNlon
+!     mscNlan
+!     NCID
+!  out:
+!     mscValueLAT
+!     mscValueLON
+!
+  IMPLICIT NONE
+
+  INCLUDE 'netcdf.inc'
+
+  INTEGER ::   mscNlon   ! number of longitude of mosaic data
+  INTEGER ::   mscNlat   ! number of latitude of mosaic data
+
+  INTEGER ::  NCID, STATUS, MSLATID,MSLONID 
+
+  INTEGER ::   NDIMS
+  PARAMETER (NDIMS=3)                  ! number of dimensions
+  INTEGER START(NDIMS), COUNT(NDIMS)
+
+  REAL ::   mscValueLAT(mscNlon,mscNlat,1)
+  REAL ::   mscValueLON(mscNlon,mscNlat,1)
+  INTEGER :: i,j
+
+  START(1)=1
+  START(2)=1
+  START(3)=1
+  COUNT(1)=mscNlon
+  COUNT(2)=mscNlat
+  COUNT(3)=1
+
+  STATUS = NF_INQ_VARID (NCID, 'grid_latt', MSLATID)
+  IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR_geo(STATUS)
+  STATUS = NF_GET_VARA_REAL (NCID, MSLATID, START, COUNT, mscValueLAT)
+  IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR_geo(STATUS)
+
+  STATUS = NF_INQ_VARID (NCID, 'grid_lont', MSLONID)
+  IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR_geo(STATUS)
+  STATUS = NF_GET_VARA_REAL (NCID, MSLONID, START, COUNT, mscValueLON)
+  IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR_geo(STATUS)
+
+end subroutine GET_geo_sngl_fv3sar
+
+Subroutine  GET_geo_sngl_fv3sar_xv(NCID,mscNlon,mscNlat,mscValueXland,mscValueVtyp)
+!
+!  Author: Ming Hu, ESRL/GSD
+!  
+!  First written: 12/16/2007.
+!
+!  IN:
+!     mscNlon
+!     mscNlan
+!     NCID
+!  out:
+!     mscValueXland
+!     mscValueVtyp 
+!
+  IMPLICIT NONE
+
+  INCLUDE 'netcdf.inc'
+
+  INTEGER ::   mscNlon   ! number of longitude of mosaic data
+  INTEGER ::   mscNlat   ! number of latitude of mosaic data
+
+  INTEGER ::  NCID, STATUS, MSXLANDID,MSVTYPID
+
+  INTEGER ::   NDIMS
+  PARAMETER (NDIMS=3)                  ! number of dimensions
+  INTEGER START(NDIMS), COUNT(NDIMS)
+
+  REAL ::   mscValueXland(mscNlon,mscNlat,1)
+  REAL ::   mscValueVtyp(mscNlon,mscNlat,1)
+  INTEGER :: i,j
+
+  START(1)=1
+  START(2)=1
+  START(3)=1
+  COUNT(1)=mscNlon
+  COUNT(2)=mscNlat
+  COUNT(3)=1
+
+  STATUS = NF_INQ_VARID (NCID, 'slmsk', MSXLANDID)
+  IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR_geo(STATUS)
+  STATUS = NF_GET_VARA_REAL (NCID, MSXLANDID, START, COUNT, mscValueXland)
+  IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR_geo(STATUS)
+
+  STATUS = NF_INQ_VARID (NCID, 'vtype', MSVTYPID)
+  IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR_geo(STATUS)
+  STATUS = NF_GET_VARA_REAL (NCID, MSVTYPID, START, COUNT, mscValueVtyp)
+  IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR_geo(STATUS)
+
+end subroutine GET_geo_sngl_fv3sar_xv

--- a/update_sst/sstGlobal2RR.f90
+++ b/update_sst/sstGlobal2RR.f90
@@ -164,7 +164,7 @@ SUBROUTINE sstGlobal2RR(f,imaskSST,xland,nlon,nlat,xlon,ylat,sstRR)
             sstRR(i,j) = F(IPOINT,JPOINT)
         ELSE
 
-     print *,' Expanded serach for water point'
+!     print *,' Expanded serach for water point'
 !
 !         EXPAND SEARCH RADIUS AND TAKE FIRST WATER TYPE MATCH
 !

--- a/update_sst/update_SST_netcdf_fv3.f90
+++ b/update_sst/update_SST_netcdf_fv3.f90
@@ -1,0 +1,407 @@
+subroutine update_SST_netcdf_fv3 (sstRR, glat, glon, nlon, nlat, xland, vegtyp, ilake,iice,iyear,imonth,iday,ihour)
+!$$$  documentation block
+!                .      .    .                                       .
+!   update_SST_netcdf_mass: read SST from wrf mass netcdf old background file
+!           and update SST in wrf mass background file
+!   prgmmr: Ming Hu                 date: 2008-02-25
+!   updates: Tanya Smirnova         date: 2010-10-11
+!
+! program history log:
+!
+!
+!   input argument list:
+!       sstRR: sst
+!       nlon:  x dimension
+!       nlat:  Y dimension
+!
+! attributes:
+!   language: f90
+!
+!$$$
+
+  use kinds, only: r_single,i_kind, r_kind
+  use mpi
+  use constants, only: init_constants,init_constants_derived
+  use constants, only: rd,h1000,rd_over_cp,grav,half
+  use gsi_rfv3io_tten_mod, only: gsi_rfv3io_get_grid_specs
+  use gsi_rfv3io_tten_mod, only: bg_fv3regfilenameg,fv3sar_bg_opt
+  use gsi_rfv3io_tten_mod, only: rfv3io_mype
+  use gsi_rfv3io_tten_mod, only: gsi_fv3ncdf_read,gsi_fv3ncdf2d_read
+  use gsi_rfv3io_tten_mod, only: gsi_fv3ncdf_write,gsi_fv3ncdf_append
+  use gsi_rfv3io_tten_mod, only: gsi_fv3ncdf_append2d
+  use gsi_rfv3io_tten_mod, only: nlon_regional,nlat_regional,nsig_regional
+  use gsi_rfv3io_tten_mod, only: eta1_ll
+
+  implicit none
+
+!
+! MPI variables
+  integer :: npe, mype, mypeLocal,ierror
+
+  INCLUDE 'netcdf.inc'
+
+  integer, parameter :: WRF_INTEGER = 106
+!
+  integer :: nlon, nlat, ilake, iice
+  real  :: sstRR(nlon,nlat)
+  real  :: glat(nlon,nlat)
+  real  :: glon(nlon,nlat)
+  real  :: xland(nlon,nlat) ! tgs is it slmsk in FV3? xland(water)=0
+  real  :: vegtyp(nlon,nlat)
+
+! Declare local parameters
+
+  character(len=120) :: flnm1
+  
+  integer(i_kind) :: i,j,k
+  
+  character (len=80), dimension(3)  ::  dimnames
+  
+  integer(i_kind) :: l, n
+  
+  integer(i_kind) :: ierr, ier, Status, Status_next_time
+  character(len=:),allocatable :: sfcvars   !='sfc_data.nc'
+
+!  character (len=31) :: rmse_var
+  integer(i_kind) iyear,imonth,iday,ihour,iminute,isecond
+!  integer(i_kind) nlon_regional,nlat_regional,nsig_regional
+  real(r_single),allocatable::field2(:,:)
+  real(r_single),allocatable::field3(:,:,:)
+  real(r_single),allocatable::surftemp(:,:)
+  real(r_single),allocatable::temp2m(:,:)
+  real(r_single),allocatable::sst(:,:)
+  real(r_single),allocatable::lu_index(:,:)
+  !tgs FV3 lake variables are lake_depth and lake_fraction
+  real(r_single),allocatable::lake_frac(:,:)
+  real(r_single),allocatable::lake_depth(:,:)
+  real(r_single),allocatable::tsea(:,:)
+  real(r_single),allocatable::tsfc(:,:)
+
+  real(r_single)    :: time, time1, time2
+  real(r_single)    :: a, b
+
+! Lakes from RUC model
+! -- Great Salt Lake lake surface temps
+        REAL salt_lake_lst (13)
+        data salt_lake_lst &
+        /1.,3.,6.,13.,17.,20.,26.,25.,20.,14.,9.,3.,1./
+! -- Salton Sea - California
+        REAL salton_lst (13)
+        data salton_lst &
+        / 12.8, 12.8, 17.2, &
+         21.1, 24.4, 26.7,  &
+         30.0, 31.7, 29.4,  &
+         25.0, 20.6, 15.0,  &
+         12.8/
+! -- Lake Champlain - Vermont
+        REAL champ_lst (13)
+        data champ_lst&
+       /  1.3,  0.6,  1.0,  &
+          3.0,  7.5, 15.5,  &
+         20.5, 21.8, 18.2,  &
+         13.0,  8.2,  4.5,  &
+          1.3/
+
+        real xc1,yc1, xc2,yc2
+        integer isup,jsup, iwin,jwin, isalton,jsalton
+
+      integer julm(13)
+      data julm/0,31,59,90,120,151,181,212,243,273,304,334,365/
+
+        INTEGER  mon1,mon2,day1,day2,juld
+        real rday,wght1,wght2
+!20aug18 - lake model
+        integer :: NCID,in_SF_LAKE_PHYSICS
+!
+        integer :: nlon_regional_smc, nlat_regional_smc, nsig_regional_smc
+
+  
+  nlon_regional=nlon
+  nlat_regional=nlat
+!
+! ===============================================================================
+!
+
+  flnm1='sfc_data.nc'
+
+!tgs - in FV3 lkm=1 is turning on the lake model, we'll do a change later when
+!      lake model is on
+  in_SF_LAKE_PHYSICS=0
+!
+!-------------  get grid info
+
+!  open and read background dimesion
+
+  fv3sar_bg_opt=1    ! 0=restart, 1=input
+  call bg_fv3regfilenameg%init
+  mype=0
+
+  sfcvars= bg_fv3regfilenameg%sfcdata
+
+!  read in background fields
+  call gsi_rfv3io_get_grid_specs(bg_fv3regfilenameg,ierror)  
+
+!
+  write(6,*) '================================================='
+  sfcvars="./sfc_data.nc"
+  write(*,*)"nlon_regional, nlat_regional", nlon_regional, nlat_regional
+
+  allocate(surftemp(nlon_regional,nlat_regional))
+  allocate(tsea(nlon_regional,nlat_regional))
+  allocate(tsfc(nlon_regional,nlat_regional))
+  allocate(temp2m(nlon_regional,nlat_regional))
+  allocate(sst(nlon_regional,nlat_regional))
+  allocate(lu_index(nlon_regional,nlat_regional))
+!tgs - so far we do not have lake info in NA RRFS. The variables in FV3 are
+!      lake_depth and lake_frac
+  allocate(lake_frac(nlon_regional,nlat_regional)) 
+  allocate(lake_depth(nlon_regional,nlat_regional))
+
+  allocate(field2(nlon_regional,nlat_regional))
+!
+  write(6,*) '================================================='
+  call gsi_fv3ncdf2d_read(sfcvars,'tsea','TSEA',field2,mype)
+  sst=field2(:,:)
+  write(*,*)'Done with reading TSEA from file ',sfcvars
+  write(6,*)' max,min bck skin temp tsea(K)=',maxval(sst),minval(sst)
+       write(6,*)'background skin temp tsea(170,170)', sst(170,170)
+       write(6,*)'new  sstRR(170,170)', sstRR(170,170)
+       write(6,*)'Winnipeg skin temp tsea(516,412)', sst(516,412)
+       write(6,*)'Winnipeg sstRR(516,412)', sstRR(516,412)
+!
+  write(6,*) '================================================='
+  call gsi_fv3ncdf2d_read(sfcvars,'tsfc','TSFC',field2,mype)
+  surftemp=field2(:,:)
+  write(*,*)'Done with reading TSFC from file ',sfcvars
+  write(6,*)' max,min bck skin temp tsfc(K)=',maxval(surftemp),minval(surftemp)
+       write(6,*)'background skin temp tsfc(170,170)', surftemp(170,170)
+       write(6,*)'Winnipeg skin temp tsfc(516,412)', surftemp(516,412)
+!
+  write(6,*) '================================================='
+  call gsi_fv3ncdf2d_read(sfcvars,'t2m','T2M',field2,mype)
+  temp2m=field2(:,:)
+  write(*,*)'Done with reading T2M from file ',sfcvars
+  write(6,*)' max,min bck 2m temp (K)=',maxval(temp2m),minval(temp2m)
+       write(6,*)'background t2 temp(292,258)', temp2m(292,258)
+       write(6,*)'new  sstRR(170,170)', sstRR(292,258)
+!
+  write(6,*) '================================================='
+!  rmse_var='LAKE_DEPTH'
+  !lake_depth=0
+  !write(6,*)' max,min bck lake_depth (K)=',maxval(lake_depth),minval(lake_depth)
+!
+  write(6,*) '================================================='
+!  rmse_var='VTYPE'
+  call gsi_fv3ncdf2d_read(sfcvars,'vtype','VTYPE',field2,mype)
+  lu_index=field2(:,:)
+  write(*,*)'Done with reading VTYPE (LU_INDEX) from file ',sfcvars
+  write(6,*)' max,min VTYPE (LU_INDEXi)=',maxval(lu_index),minval(lu_index)
+!
+  write(6,*) '================================================='
+!  rmse_var='LAKE_FRAC'
+  lake_frac=0
+  !write(6,*)' max,min LAKEMASK=',maxval(lake_frac),minval(lake_frac)
+!
+! Compute weight for the current date
+       juld = julm(imonth) + iday
+       if(juld.le.15) juld=juld+365
+
+       mon2 = imonth
+       if(iday.gt.15) mon2 = mon2 + 1
+       if(mon2.eq.1) mon2=13
+       mon1=mon2-1
+! **** Assume data valid at 15th of month
+       day2=julm(mon2)+15
+       day1=julm(mon1)+15
+       rday=juld
+       wght1=(day2-rday)/float(day2-day1)
+       wght2=(rday-day1)/float(day2-day1)
+       write(6,*)'Date weights =',wght1,wght2
+
+!
+!  update skin temperature over water
+!
+if(1==1) then  ! turn off , use GFS SST
+! find i,j for a point in northern Lake Superior
+  DO J=1,nlat
+  DO I=1,nlon
+   if((glat(i,j)>48.4 .and. glat(i,j)<49.6) .and. (glon(i,j)<-87.9 .and. glon(i,j)>-88.1)) then
+     isup=i
+     jsup=j
+     print *,' Lake Superior --> i,j,glat(i,j),glon(i,j)',i,j,glat(i,j),glon(i,j), &
+     'vegtyp(i,j)=',vegtyp(i,j),'lu_index(i,j)',lu_index(i,j),xland(i,j)
+     goto 99
+   endif
+  ENDDO
+  ENDDO
+
+99  continue
+
+! find i,j for a point in northern Lake Winnipeg
+  DO J=1,nlat
+  DO I=1,nlon
+   if((glat(i,j)>53.3 .and. glat(i,j)<53.7) .and. (glon(i,j)<-98.3 .and.  glon(i,j)>-98.7)) then
+     iwin=i
+     jwin=j
+     print *,' Lake Winnipeg --> i,j,glat(i,j),glon(i,j)',i,j,glat(i,j),glon(i,j), &
+     'vegtyp(i,j)=',vegtyp(i,j),'lu_index(i,j)',lu_index(i,j),xland(i,j)
+     goto 999
+   endif
+  ENDDO
+  ENDDO
+
+999  continue
+
+  write(*,*) 'in_SF_LAKE_PHYSICS:', in_SF_LAKE_PHYSICS
+       
+  DO J=1,nlat
+  DO I=1,nlon
+    if( xland(i,j) < 0.00001 ) then    ! water, xland = 0
+    ! only unfrozen water points (sea or lakes)
+       if(in_SF_LAKE_PHYSICS == 0 .and. lake_depth(i,j) > 0.) then
+       ! --- CLM lake model is off, use climatology for several lakes
+       ! --- Great Salt Lake, Utah Lake -- Utah
+            if (glat(i,j).gt.39.5 .and. glat(i,j).lt.42. .and.  &
+               glon(i,j).gt.-114..and. glon(i,j).lt.-111.) then
+               write(6,*)'Global data Salt Lake temp',i,j,sstRR(i,j)
+               sstRR(i,j) = 273.15 + wght1*salt_lake_lst(mon1)  &
+                       +wght2*salt_lake_lst(mon2)
+                write(6,*)'Climatology Salt Lake temp',i,j,sstRR(i,j)  &
+                          ,glat(i,j),glon(i,j)
+            end if
+
+            ! --- Salton Sea -- California
+            if (glat(i,j).gt.33. .and. glat(i,j).lt.33.7 .and.  &
+                glon(i,j).gt.-116.3 .and. glon(i,j).lt.-115.3) then
+            write(6,*)'Global data Salton Sea temp',i,j,sstRR(i,j)
+            sstRR(i,j) = 273.15 + wght1*salton_lst(mon1)  &  
+                       +wght2*salton_lst(mon2)
+            write(6,*)'Climatology Salton Sea temp',i,j,sstRR(i,j)  &
+                ,glat(i,j),glon(i,j)
+              isalton=i
+              jsalton=j
+            end if
+
+            ! --- Lake Champlain -- Vermont
+            if (glat(i,j).gt.44. .and. glat(i,j).lt.45.2 .and.  &
+               glon(i,j).gt.-74. .and. glon(i,j).lt.-73.) then
+            write(6,*)'Global data Lake Champlain temp',i,j,sstRR(i,j)
+            sstRR(i,j) = 273.15 + wght1*champ_lst(mon1)  &
+                       +wght2*champ_lst(mon2)
+            write(6,*)'Climatology Lake Champlain temp',i,j,sstRR(i,j)  &
+                ,glat(i,j),glon(i,j)
+            end if
+            ! --- For Lake Nipigon, use point for n. Lake Superior
+            !   -- Lake Nipigon is deep!
+            if (glat(i,j).gt.49. .and. glat(i,j).lt.51. .and. &
+               glon(i,j).gt.-90. .and. glon(i,j).lt.-87.) then
+               write(6,*)'Global data Lake Nipigon temp',i,j,sstRR(i,j)
+                sstRR(i,j) = sstRR(isup,jsup)
+                write(6,*)'Lake Nipigon temp',i,j,sstRR(i,j) &
+                 ,glat(i,j),glon(i,j)
+            end if
+
+     if(1 == 2) then
+! --- For Lake of the Woods and other
+!      Minnesota lakes, use point for n. Lake Winnipeg
+!    -- These lakes are NOT DEEP!
+            if (glat(i,j).gt.46. .and. glat(i,j).lt.50. .and.  &
+               glon(i,j).gt.-96. .and. glon(i,j).lt.-93.) then
+                write(6,*)'Global data Minnesota lake temp',i,j,sstRR(i,j)
+                sstRR(i,j) = sstRR(iwin,jwin)
+                write(6,*)'Minnesota lake temp',i,j,sstRR(i,j) &
+                 ,glat(i,j),glon(i,j)
+            end if
+
+! --- For Canadian lakes, including Winnipeg, Manitoba, Winnipegosis,
+!      use point for n. Lake Winnipeg
+!    -- These lakes are NOT DEEP!
+            if (glat(i,j).gt.50. .and. glat(i,j).lt.68. .and.  &
+               glon(i,j).gt.-148. .and. glon(i,j).lt.-48.) then
+                write(6,*)'Global data Canadian lake temp',i,j,sstRR(i,j)
+                sstRR(i,j) = sstRR(iwin,jwin)
+                write(6,*)'Canadian lake temp',i,j,sstRR(i,j) &
+                 ,glat(i,j),glon(i,j)
+            end if
+! --- For lakes in Washington, Oregon, Nevada
+!      use point for n. Lake Winnipeg (?????)
+!    -- These lakes are NOT DEEP!
+            if (glat(i,j) > 33.8 .and. glat(i,j) < 50. .and.  &
+               glon(i,j) < -114. ) then
+                write(6,*)'Global data US west lake temp',i,j,sstRR(i,j)
+                sstRR(i,j) = sstRR(iwin,jwin)
+!                sstRR(i,j) = sstRR(isalton,jsalton)
+                write(6,*)'US west lake temp',i,j,sstRR(i,j) &
+                 ,glat(i,j),glon(i,j)
+            end if
+
+     endif ! 1 == 2
+      endif   ! lakes
+
+!-- update skin temp for water points
+! in_SF_LAKE_PHYSICS == 0 --> lakemask == 0, SST is updated at all water points
+! in_SF_LAKE_PHYSICS == 1 --> lakemask == 1 where CLM lake model is applied, SST is
+! not updated at these points.
+           if( lake_frac(i,j) == 0.) then
+               surftemp(i,j) = sstRR(i,j)
+           endif
+
+           if(sstRR(i,j) > 400. .or. sstRR(i,j) < 100. ) then
+             print *,'Bad SST at point i,j',i,j,sstRR(i,j)
+           endif
+
+    elseif (xland(i,j) > 1.99) then ! ice, xland = 2
+    ! frozen water - xland = 2
+          if(in_SF_LAKE_PHYSICS == 0) then
+          ! CLM lake model is turned off
+            if( lake_depth(i,j) > 0. .and. sstRR(i,j) > 273.) then
+            ! -- frozen lakes with CLM lake model turned off.
+              print *,'Ice lake cannnot have SST > 274K'
+              !print *,'i,j,sstRR,lu_index,vegtyp =' ,i,j,sstRR(i,j),lu_index(i,j),vegtyp(i,j)
+
+              !set skin temp of frozen lakes to 2-m temperature
+              sstRR(i,j)= min(273.15,temp2m(i,j))
+
+              !update skin temp for frozen lakes
+              surftemp(i,j)=sstRR(i,j)
+            endif
+          endif ! in_SF_LAKE_PHYSICS == 0
+
+    endif  ! water or ice
+
+    ! update SST 
+    sst(i,j)=sstRR(i,j)
+  ENDDO
+  ENDDO
+  write(*,*) 'Skin temperature updated with current SST'
+       write(6,*)' updated skin temp(170,170)', surftemp(170,170)
+       write(6,*)' max,min skin temp =',maxval(surftemp),minval(surftemp)
+endif  ! 1==1, when 1==2 SST update is turned off
+!
+!
+!           update fv3 netcdf file with new SST
+!
+  write(6,*) ' ============================= '
+  write(6,*) ' update SST in background file '
+  write(6,*) ' ============================= '
+  flnm1='sfc_data.nc'
+  sfcvars='./sfc_data.nc'
+     
+!-------------  get date info
+
+  write(6,*) ' Update SST in background at time:'
+  write(6,*)' iy,m,d,h,m,s=',iyear,imonth,iday,ihour
+
+  write(6,*) '================================================='
+  write(6,*)' max,min skin temp =',maxval(surftemp),minval(surftemp)
+  call gsi_fv3ncdf_append2d(sfcvars,'tsea',sst,mype)
+  call gsi_fv3ncdf_append2d(sfcvars,'tsfc',surftemp,mype)
+  deallocate(field2)
+
+  call MPI_Barrier(mpi_comm_world, ierror)
+  close(6)
+  if(mype==0)  write(*,*) "=== FV3 UPDATESST SUCCESS ==="
+
+end subroutine update_SST_netcdf_fv3
+
+


### PR DESCRIPTION
Added changes for updatesst to work for RRFS. No lake model considered for now. 
The following files are needed in the run directory, besides the executable **process_updatesst**:    **sfc_data.nc** , **fv3_akbk**, **fv3_grid_spec** , **sst.namelist**

Here is an example of sst.namelist
```
&setup
  bkversion=1,
  iyear=2021
  imonth=08
  iday=24 
  ihr=00  
 /
```