### PR TITLE
add capability of estimating rain number concentration from rain mixing ratio

### DIFF
--- a/cloudanalysis/cloudanalysis_fv3driver.f90
+++ b/cloudanalysis/cloudanalysis_fv3driver.f90
@@ -53,7 +53,9 @@ program cloudanalysis
                                       l_use_hydroretrieval_all, &
                                       i_lightpcp, l_numconc, qv_max_inc,ioption, &
                                       l_precip_clear_only,l_fog_off,cld_bld_coverage,cld_clr_coverage,&
-                                      i_T_Q_adjust,l_saturate_bkCloud,i_precip_vertical_check,l_rtma3d
+                                      i_T_Q_adjust,l_saturate_bkCloud,i_precip_vertical_check,l_rtma3d, &
+                                      l_qnr_from_qr, n0_rain
+
   use namelist_mod, only: load_namelist
   use namelist_mod, only: iyear,imonth,iday,ihour,iminute,isecond
   use namelist_mod, only: fv3_io_layout_y
@@ -227,6 +229,9 @@ program cloudanalysis
   real(r_kind),parameter    :: pi = 4._r_kind*atan(1._r_kind)
   real(r_kind),parameter    :: rho_w = 999.97_r_kind, rho_a = 1.2_r_kind
   real(r_kind),parameter    :: cldDiameter = 10.0E3_r_kind
+
+  real(r_kind),parameter :: am_r = pi * 1000.0_r_kind / 6.0_r_kind
+  real(r_kind)           :: lambda
 
 ! local variables used for adjustment of qr/qs for RTMA_3D to alleviate ghost reflectivity
   logical         :: print_verbose
@@ -1129,6 +1134,33 @@ program cloudanalysis
         end do
      end do
   endif
+
+!
+! If requested, compute rain number concentration from rain mixing
+! ratio by assuming an exponential distribution.  The method is a
+! simplified version of the make_RainNumber function in the UFS
+! module_mp_thompson_make_number_concentrations.F90.
+!
+  if (l_qnr_from_qr) then
+    write(6,*) 'compute rain number concentration from rain mixing ratio'
+    write(6,*) 'n0_rain = ', n0_rain
+    do k=1,nsig
+       do j=1,lat2
+          do i=1,lon2
+             if (rain_3d(i,j,k) < 0.000000000001_r_kind) then
+                rain_3d(i,j,k)  = zero
+                nrain_3d(i,j,k) = zero
+             else
+                lambda = sqrt(sqrt(n0_rain*am_r*6.0_r_kind/rain_3d(i,j,k)))
+                nrain_3d(i,j,k) = rain_3d(i,j,k) / 6.0_r_kind &
+                                  * lambda*lambda*lambda / am_r
+             endif
+          end do
+       end do
+    end do
+  endif
+
+
 !
 !  remove any negative hydrometeor mixing ratio or number concentration values
 !

--- a/cloudanalysis/namelist_mod.f90
+++ b/cloudanalysis/namelist_mod.f90
@@ -43,7 +43,8 @@ module namelist_mod
                             i_coastline,i_gsdqc,qv_max_inc,ioption,l_precip_clear_only,l_fog_off,&
                             cld_bld_coverage,cld_clr_coverage,&
                             i_cloud_q_innovation,i_ens_mean,DTsTmax,&
-                            i_T_Q_adjust,l_saturate_bkCloud,l_rtma3d,i_precip_vertical_check
+                            i_T_Q_adjust,l_saturate_bkCloud,l_rtma3d,i_precip_vertical_check,&
+                            l_qnr_from_qr,n0_rain
 
 
   implicit none
@@ -69,7 +70,8 @@ module namelist_mod
                                 i_coastline,i_gsdqc,qv_max_inc,ioption,l_precip_clear_only,l_fog_off,&
                                 cld_bld_coverage,cld_clr_coverage,&
                                 i_cloud_q_innovation,i_ens_mean,DTsTmax, &
-                                i_T_Q_adjust,l_saturate_bkCloud,l_rtma3d,i_precip_vertical_check
+                                i_T_Q_adjust,l_saturate_bkCloud,l_rtma3d,i_precip_vertical_check,&
+                                l_qnr_from_qr,n0_rain
 
     integer :: ios
     integer :: iyear,imonth,iday,ihour,iminute,isecond

--- a/cloudanalysis/rapidrefresh_cldsurf_mod.f90
+++ b/cloudanalysis/rapidrefresh_cldsurf_mod.f90
@@ -179,6 +179,9 @@ module rapidrefresh_cldsurf_mod
 !                          = 2(clean Qg as in 1, and adjustment to the retrieved Qr/Qs/Qnr throughout the whole profile)
 !                          = 3(similar to 2, but adjustment to Qr/Qs/Qnr only below maximum reflectivity level
 !                           and where the dbz_obs is missing);
+!      l_qnr_from_qr   - if .true. compute rain number concentration from rain mixing ratio,
+!                        assuming an exponential distribution
+!      n0_rain         - intercept parameter (m**-4) for raindrop size distribution
 !
 ! attributes:
 !   language: f90
@@ -250,6 +253,8 @@ module rapidrefresh_cldsurf_mod
   public :: l_saturate_bkCloud
   public :: l_rtma3d
   public :: i_precip_vertical_check
+  public :: l_qnr_from_qr
+  public :: n0_rain
 
   logical l_hydrometeor_bkio
   real(r_kind)  dfi_radar_latent_heat_time_period
@@ -308,6 +313,8 @@ module rapidrefresh_cldsurf_mod
   logical              l_saturate_bkCloud
   logical              l_rtma3d
   integer(i_kind)      i_precip_vertical_check
+  logical              l_qnr_from_qr
+  real(r_kind)         n0_rain
 
 contains
 
@@ -416,6 +423,8 @@ contains
     l_saturate_bkCloud= .true.
     l_rtma3d            = .false.                     ! turn configuration for rtma3d off          
     i_precip_vertical_check = 0                       ! No check and adjustment to retrieved Qr/Qs/Qg (default)
+    l_qnr_from_qr = .false.
+    n0_rain = 100000000.0_r_kind          ! in m**-4; default value assumes smaller drops than in M-P distribution
 
     return
   end subroutine init_rapidrefresh_cldsurf


### PR DESCRIPTION
Analyzing rain number concentration with EnKF / EnVar radar-reflectivity data assimilation remains a research subject.  But we do get useful rain mixing ratios from the radar DA, and we need to pair the mixing ratio estimates with reasonable values of number concentration.  The cloud analysis runs immediately after radar DA and before the forecast and is thus the appropriate place to initialize rain number concentration.  The number concentration is computed from mixing ratio by assuming the drop sizes have an exponential distribution, with the intercept parameter specified with a new namelist parameter "n0_rain".  This new capability is turned on during the cloud analysis by setting the new namelist parameter "l_qnr_from_qr" to true.  The default value of "l_qnr_from_qr" is false.