### PR TITLE
bug fix for PR21: continuation line syntax

### DIFF
--- a/cloudanalysis/cloudanalysis_fv3driver.f90
+++ b/cloudanalysis/cloudanalysis_fv3driver.f90
@@ -54,7 +54,7 @@ program cloudanalysis
                                       i_lightpcp, l_numconc, qv_max_inc,ioption, &
                                       l_precip_clear_only,l_fog_off,cld_bld_coverage,cld_clr_coverage,&
                                       i_T_Q_adjust,l_saturate_bkCloud,i_precip_vertical_check,l_rtma3d, &
-                                      l_qnr_from_qr, n0_rain,
+                                      l_qnr_from_qr, n0_rain, &
                                       r_cloudfrac_threshold
 
   use namelist_mod, only: load_namelist


### PR DESCRIPTION
NOTE:
This is a bug fix for PR#21, Read RRFS bkgd cld fraction for use in the cloud analysis
https://github.com/NOAA-GSL/rrfs_utl/pull/21

It adds a continuation character for the initial parameter list.

DESCRIPTION OF CHANGES:
Tests have shown that the RRFS cloud analysis can be improved by including a test in the cloud-building stage, to see how high the background cloud fraction is. If there is sufficient cloud fraction (e.g., >0.45) then no building is performed.

To add cloud fraction, it is necessary to include the links to the RRFS intermediate file (phy_data.nc) containing the cloud fraction values. This change is is PR #427.

This PR contains the Fortran code changes to use the cloud fraction data in the cloud analysis.

TESTS CONDUCTED:
A 5-day retrospective case was run for Spring 2021, using the RRFS Base D version. Verification showed that there were small improvements in low-level moisture (RH) and in ceiling, especially the bias values.

DEPENDENCIES:
This change depends on PR #427 (linking the RRFS cloud fraction data) to use cloud fraction in the cloud analysis.

CONTRIBUTORS (optional):
Terra Ladwig