### PR TITLE
fixes for building with gfortran

### DIFF
--- a/baselib/CMakeLists.txt
+++ b/baselib/CMakeLists.txt
@@ -3,6 +3,7 @@ set(module_dir "${CMAKE_CURRENT_BINARY_DIR}/include")
 add_library(ncio STATIC module_ncio.f90)
 add_library(${PROJECT_NAME}::ncio ALIAS ncio)
 set_target_properties(ncio PROPERTIES Fortran_MODULE_DIRECTORY "${module_dir}")
+target_link_libraries(ncio PUBLIC NetCDF::NetCDF_Fortran)
 target_include_directories(ncio PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
                                        $<INSTALL_INTERFACE:include>)
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include DESTINATION ${CMAKE_INSTALL_PREFIX})

--- a/bufrsnd/rrfs_bufr.fd/PROF_FV3SAR_NET.f
+++ b/bufrsnd/rrfs_bufr.fd/PROF_FV3SAR_NET.f
@@ -764,18 +764,28 @@ C Getting start time
         LRECPR=4*(8+9+LCL1ML*LM+LCL1SL)
 ! former parameter statements
 
-        if (allocated(FPACK)) deallocate(FPACK); allocate(FPACK(NWORDM))
-        if (allocated(PRODAT)) deallocate(PRODAT); allocate(PRODAT(NWORDM))
-        if (ALLOCATED(DUM)) deallocate(DUM);allocate(DUM(IM,JM,4))
-        if (ALLOCATED(DUMMY)) deallocate(DUMMY); allocate(DUMMY(IM,JM))
-        if (ALLOCATED(DUMMY2)) deallocate(DUMMY2);allocate(DUMMY2(IM,JM))
+        if (allocated(FPACK)) deallocate(FPACK)
+        allocate(FPACK(NWORDM))
+        if (allocated(PRODAT)) deallocate(PRODAT)
+        allocate(PRODAT(NWORDM))
+        if (ALLOCATED(DUM)) deallocate(DUM)
+        allocate(DUM(IM,JM,4))
+        if (ALLOCATED(DUMMY)) deallocate(DUMMY) 
+        allocate(DUMMY(IM,JM))
+        if (ALLOCATED(DUMMY2)) deallocate(DUMMY2)
+        allocate(DUMMY2(IM,JM))
 
-        if (ALLOCATED(DUM3D)) deallocate(DUM3D); allocate(DUM3D(NUMSTA,LM))
-        if (ALLOCATED(DUM3D2)) deallocate(DUM3D2);allocate(DUM3D2(NUMSTA,LM))
-        if (ALLOCATED(DUM3D3)) deallocate(DUM3D3);allocate(DUM3D3(NUMSTA,LM))
-        if (ALLOCATED(DUM3D4)) deallocate(DUM3D4);allocate(DUM3D4(NUMSTA,LM))
+        if (ALLOCATED(DUM3D)) deallocate(DUM3D) 
+        allocate(DUM3D(NUMSTA,LM))
+        if (ALLOCATED(DUM3D2)) deallocate(DUM3D2)
+        allocate(DUM3D2(NUMSTA,LM))
+        if (ALLOCATED(DUM3D3)) deallocate(DUM3D3)
+        allocate(DUM3D3(NUMSTA,LM))
+        if (ALLOCATED(DUM3D4)) deallocate(DUM3D4)
+        allocate(DUM3D4(NUMSTA,LM))
 
-        if (ALLOCATED(LMH)) deallocate(LMH);allocate(LMH(IM,JM))
+        if (ALLOCATED(LMH)) deallocate(LMH)
+        allocate(LMH(IM,JM))
 
 
 !!!!!

--- a/bufrsnd/rrfs_bufr.fd/PROF_FV3SAR_NET.f
+++ b/bufrsnd/rrfs_bufr.fd/PROF_FV3SAR_NET.f
@@ -765,26 +765,17 @@ C Getting start time
 ! former parameter statements
 
         if (allocated(FPACK)) deallocate(FPACK); allocate(FPACK(NWORDM))
-        if (allocated(PRODAT)) deallocate(PRODAT);
-     &                  allocate(PRODAT(NWORDM))
-        if (ALLOCATED(DUM)) deallocate(DUM);
-     &                          allocate(DUM(IM,JM,4))
-        if (ALLOCATED(DUMMY)) deallocate(DUMMY);
-     &                          allocate(DUMMY(IM,JM))
-        if (ALLOCATED(DUMMY2)) deallocate(DUMMY2);
-     &                          allocate(DUMMY2(IM,JM))
+        if (allocated(PRODAT)) deallocate(PRODAT); allocate(PRODAT(NWORDM))
+        if (ALLOCATED(DUM)) deallocate(DUM);allocate(DUM(IM,JM,4))
+        if (ALLOCATED(DUMMY)) deallocate(DUMMY); allocate(DUMMY(IM,JM))
+        if (ALLOCATED(DUMMY2)) deallocate(DUMMY2);allocate(DUMMY2(IM,JM))
 
-        if (ALLOCATED(DUM3D)) deallocate(DUM3D);
-     &                          allocate(DUM3D(NUMSTA,LM))
-        if (ALLOCATED(DUM3D2)) deallocate(DUM3D2);
-     &                          allocate(DUM3D2(NUMSTA,LM))
-        if (ALLOCATED(DUM3D3)) deallocate(DUM3D3);
-     &                          allocate(DUM3D3(NUMSTA,LM))
-        if (ALLOCATED(DUM3D4)) deallocate(DUM3D4);
-     &                          allocate(DUM3D4(NUMSTA,LM))
+        if (ALLOCATED(DUM3D)) deallocate(DUM3D); allocate(DUM3D(NUMSTA,LM))
+        if (ALLOCATED(DUM3D2)) deallocate(DUM3D2);allocate(DUM3D2(NUMSTA,LM))
+        if (ALLOCATED(DUM3D3)) deallocate(DUM3D3);allocate(DUM3D3(NUMSTA,LM))
+        if (ALLOCATED(DUM3D4)) deallocate(DUM3D4);allocate(DUM3D4(NUMSTA,LM))
 
-        if (ALLOCATED(LMH)) deallocate(LMH);
-     &                          allocate(LMH(IM,JM))
+        if (ALLOCATED(LMH)) deallocate(LMH);allocate(LMH(IM,JM))
 
 
 !!!!!

--- a/bufrsnd/rrfs_sndp.fd/CALWXT_BOURG.f
+++ b/bufrsnd/rrfs_sndp.fd/CALWXT_BOURG.f
@@ -72,7 +72,7 @@ C
       PTYPE=0
       IF (PPT.LE.PTHRES) RETURN
 
-      T1=RTC()
+      T1=secnds(0.0)
       PSFCK=PINT(LMHK+1)
 C
 C   SKIP THIS POINT IF NO PRECIP THIS TIME STEP 
@@ -156,9 +156,9 @@ C             RAIN = 8
           ELSE
 C             TRANSITION ZONE, ASSUME EQUALLY LIKELY RAIN/SNOW
 C             PICKING A RANDOM NUMBER, IF <=0.5 SNOW
-              t2=rtc() 
+              t2=secnds(0.0) 
               ta=t2-t1
-              call srand(ta)
+              call srand(int(ta))
 !              r1 = rand()
               IF (r1.le.0.5) THEN
 C                 SNOW = 1
@@ -192,9 +192,9 @@ C                 RAIN = 8
               ELSE
 C                 TRANSITION ZONE, ASSUME EQUALLY LIKELY IP/RAIN
 C                 PICKING A RANDOM NUMBER, IF <=0.5 IP
-                  t2=rtc()
+                  t2=secnds(0.0)
                   ta=t2-t1
-                  call srand(ta)
+                  call srand(int(ta))
 !                  r1 = rand()
                   IF (r1.le.0.5) THEN
 C                     ICE PELLETS = 2
@@ -221,9 +221,9 @@ C                 RAIN = 8
           ELSE
 C             TRANSITION ZONE, ASSUME EQUALLY LIKELY IP/ZR
 C             PICKING A RANDOM NUMBER, IF <=0.5 IP
-              t2=rtc()
+              t2=secnds(0.0)
               ta=t2-t1
-              call srand(ta)
+              call srand(int(ta))
 !              r1 = rand()
               IF (r1.le.0.5) THEN
 C                 STILL NEED TO CHECK POSITIVE ENERGY
@@ -239,9 +239,9 @@ C                     RAIN = 8
                   ELSE
 C                     TRANSITION ZONE, ASSUME EQUALLY LIKELY IP/RAIN
 C                     PICKING A RANDOM NUMBER, IF <=0.5 IP
-                      t2=rtc()
+                      t2=secnds(0.0)
                       ta=t2-t1
-                      call srand(ta)
+                      call srand(int(ta))
                       r2 = rand()
                       IF (r2.le.0.5) THEN
 C                         ICE PELLETS = 2

--- a/bufrsnd/rrfs_sndp.fd/CALWXT_RAMER.f
+++ b/bufrsnd/rrfs_sndp.fd/CALWXT_RAMER.f
@@ -28,7 +28,7 @@ C
 C
       INTEGER ptyp
 C
-      REAL rcp, flg, flag, xxx, pq(lm), tq(lm), twq(lm), rhq(lm), mye,
+      REAL flg, flag, xxx, pq(lm), tq(lm), twq(lm), rhq(lm), mye,
      *              qq(lm), icefrac, tqtmp(lm), pqtmp(lm), rhqtmp(lm),
      *              pint(lm+1), ttq(lm), ppq(lm), ppint(lm+1),
      *              pinttmp(lm+1)

--- a/bufrsnd/rrfs_sndp.fd/CMakeLists.txt
+++ b/bufrsnd/rrfs_sndp.fd/CMakeLists.txt
@@ -15,7 +15,6 @@ list(APPEND src_rrfs_sndp
   VAP.f
   WETBLB.f)
 
-set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffixed-line-length-120")
 add_executable(rrfs_sndp.exe ${src_rrfs_sndp})
 target_link_libraries(rrfs_sndp.exe PRIVATE bufr::bufr_4)
 

--- a/bufrsnd/rrfs_sndp.fd/CMakeLists.txt
+++ b/bufrsnd/rrfs_sndp.fd/CMakeLists.txt
@@ -15,6 +15,7 @@ list(APPEND src_rrfs_sndp
   VAP.f
   WETBLB.f)
 
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffixed-line-length-120")
 add_executable(rrfs_sndp.exe ${src_rrfs_sndp})
 target_link_libraries(rrfs_sndp.exe PRIVATE bufr::bufr_4)
 

--- a/ens_mean_recenter/ens_mean_recenter.f90
+++ b/ens_mean_recenter/ens_mean_recenter.f90
@@ -220,7 +220,7 @@ PROGRAM ens_mean_recenter
            write(6,*)' problem opening ', trim(filename),' fileid=',mype_fileid,', Status =',iret
            write(6,*)  nf90_strerror(iret)
            call flush(6)
-           stop(333)
+           stop 333 
         endif
         if(mype==0) write(*,*) 'reading ensemble member =',iens
 
@@ -268,7 +268,7 @@ PROGRAM ens_mean_recenter
            write(6,*)' problem opening ', trim(filename),' fileid=',mype_fileid,', Status =',iret
            write(6,*)  nf90_strerror(iret)
            call flush(6)
-           stop(555)
+           stop 555 
         endif
         if(mype==0) write(*,*) 'write ensemble mean = ', &
                                 trim(input_ensmean_file(mype_fileid))
@@ -323,7 +323,7 @@ PROGRAM ens_mean_recenter
               write(6,*)' problem opening ', trim(filename),' fileid=',mype_fileid,', Status =',iret
               write(6,*)  nf90_strerror(iret)
               call flush(6)
-              stop(444)
+              stop 444 
            endif
            if(mype==0) write(*,*) 'update ensemble member =',iens
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES:

Currently, rrfs_utils will not build with the gfortran compiler due to some unsupported intrinsic calls to rtc(), non-standard syntax and implicit type conversions. There is also a missing dependency on NetCDF fortran which was causing problems. 

## TESTS CONDUCTED:

To Date, no runtime tests have been conducted. The code now builds to completion with gnu/9.2.0 and openmpi on Hera. 

## DEPENDENCIES:

None

## DOCUMENTATION:

No extra documentation should be needed.

