### PR TITLE
More fixes for gnu

### DIFF
--- a/adjust_soiltq/module_bkio_fv3lam_parall.f90
+++ b/adjust_soiltq/module_bkio_fv3lam_parall.f90
@@ -397,7 +397,7 @@ if(mype==1) then
            write(6,*)' problem opening ', trim(thisfv3file),', Status =',iret
            write(6,*)  nf90_strerror(iret)
            call flush(6)
-           stop(333)
+           stop 333
        endif
        iret=nf90_inq_varid(ncioid,"zaxis_1",var_id)
        iret=nf90_Inquire_Dimension(ncioid, var_id, len = nz)
@@ -450,7 +450,7 @@ if(mype==2) then
            write(6,*)' problem opening ', trim(thisfv3file),', Status =',iret
            write(6,*)  nf90_strerror(iret)
            call flush(6)
-           stop(333)
+           stop 333
        endif
 
        iret=nf90_inq_varid(ncioid,"zaxis_1",var_id)
@@ -490,7 +490,7 @@ if(mype==3) then
            write(6,*)' problem opening ', trim(thisfv3file),', Status =',iret
            write(6,*)  nf90_strerror(iret)
            call flush(6)
-           stop(333)
+           stop 333
        endif
 
        iret=nf90_inq_varid(ncioid,"zaxis_1",var_id)
@@ -524,7 +524,7 @@ if(mype==4) then
            write(6,*)' problem opening ', trim(thisfv3file),', Status =',iret
            write(6,*)  nf90_strerror(iret)
            call flush(6)
-           stop(333)
+           stop 333
        endif
        iret=nf90_inq_varid(ncioid,"zaxis_1",var_id)
        iret=nf90_Inquire_Dimension(ncioid, var_id, len = nz)


### PR DESCRIPTION
Fixes compilation issue for GNU compilers unable to process "stop(XXX)" commands by replacing the commands with "stop XXX".

## TESTS CONDUCTED:

Tested builds with both GNU and Intel compilers successfully on Hera.

## DEPENDENCIES:

None.

## DOCUMENTATION:

None

