### PR TITLE
Change for using restart files from 32bit CCPP

### DIFF
--- a/adjust_soiltq/module_bkio_fv3lam_parall.f90
+++ b/adjust_soiltq/module_bkio_fv3lam_parall.f90
@@ -187,8 +187,8 @@ contains
     integer :: id,fv3_io_layout_y
     integer :: nlon,nlat,nlat_local,nz
     integer :: i,j,k
-    real(r_kind),allocatable :: r2d8b(:,:)
-    real(r_kind),allocatable :: r3d8b(:,:,:)
+    real,allocatable :: r2d4b(:,:)
+    real,allocatable :: r3d4b(:,:,:)
 
     nlon=this%nlon
     nlat=this%nlat
@@ -217,31 +217,31 @@ contains
 
        call fv3io%open(trim(thisfv3file),'w',200)
 ! 
-       allocate(r2d8b(nlon,nlat_local))
-       r2d8b(:,:)=this%ges_tsk(:,this%fv3_layout_begin(id):this%fv3_layout_end(id))
-       call fv3io%replace_var("tsfcl",nlon,nlat_local,r2d8b)
+       allocate(r2d4b(nlon,nlat_local))
+       r2d4b(:,:)=this%ges_tsk(:,this%fv3_layout_begin(id):this%fv3_layout_end(id))
+       call fv3io%replace_var("tsfcl",nlon,nlat_local,r2d4b)
 
-       r2d8b(:,:)=this%tsk_comp(:,this%fv3_layout_begin(id):this%fv3_layout_end(id))
-       call fv3io%replace_var("tsfc",nlon,nlat_local,r2d8b)
+       r2d4b(:,:)=this%tsk_comp(:,this%fv3_layout_begin(id):this%fv3_layout_end(id))
+       call fv3io%replace_var("tsfc",nlon,nlat_local,r2d4b)
 
-       r2d8b(:,:)=this%ges_soilt1(:,this%fv3_layout_begin(id):this%fv3_layout_end(id))
-       call fv3io%replace_var("tsnow_land",nlon,nlat_local,r2d8b)
+       r2d4b(:,:)=this%ges_soilt1(:,this%fv3_layout_begin(id):this%fv3_layout_end(id))
+       call fv3io%replace_var("tsnow_land",nlon,nlat_local,r2d4b)
 
-       r2d8b(:,:)=this%ges_qvg(:,this%fv3_layout_begin(id):this%fv3_layout_end(id))
-       call fv3io%replace_var("qwv_surf_land",nlon,nlat_local,r2d8b)
+       r2d4b(:,:)=this%ges_qvg(:,this%fv3_layout_begin(id):this%fv3_layout_end(id))
+       call fv3io%replace_var("qwv_surf_land",nlon,nlat_local,r2d4b)
 
-       r2d8b(:,:)=this%ges_qcg(:,this%fv3_layout_begin(id):this%fv3_layout_end(id))
-       call fv3io%replace_var("clw_surf_land",nlon,nlat_local,r2d8b)
+       r2d4b(:,:)=this%ges_qcg(:,this%fv3_layout_begin(id):this%fv3_layout_end(id))
+       call fv3io%replace_var("clw_surf_land",nlon,nlat_local,r2d4b)
 
-       deallocate(r2d8b)
+       deallocate(r2d4b)
 
-       allocate(r3d8b(nlon,nlat_local,nz))
-       r3d8b(:,:,:)=this%ges_tslb(:,this%fv3_layout_begin(id):this%fv3_layout_end(id),:)
-       call fv3io%replace_var("tslb",nlon,nlat_local,nz,r3d8b)
-       r3d8b(:,:,:)=this%ges_smois(:,this%fv3_layout_begin(id):this%fv3_layout_end(id),:)
-       call fv3io%replace_var("smois",nlon,nlat_local,nz,r3d8b)
+       allocate(r3d4b(nlon,nlat_local,nz))
+       r3d4b(:,:,:)=this%ges_tslb(:,this%fv3_layout_begin(id):this%fv3_layout_end(id),:)
+       call fv3io%replace_var("tslb",nlon,nlat_local,nz,r3d4b)
+       r3d4b(:,:,:)=this%ges_smois(:,this%fv3_layout_begin(id):this%fv3_layout_end(id),:)
+       call fv3io%replace_var("smois",nlon,nlat_local,nz,r3d4b)
 
-       deallocate(r3d8b)
+       deallocate(r3d4b)
        call fv3io%close
     enddo
 
@@ -563,12 +563,12 @@ if(mype==0) then
        call fv3io%open(trim(thisfv3file),'r',200)
        call fv3io%get_dim("zaxis_1",nz)
 ! slmsk: 0 - water, 1 - land, 2 - ice
-       allocate(r2d8b(nlon,nlat_local))
-       call fv3io%get_var("slmsk",nlon,nlat_local,r2d8b)
-       this%landmask(:,this%fv3_layout_begin(id):this%fv3_layout_end(id))=r2d8b(:,:)
+       allocate(r2d4b(nlon,nlat_local))
+       call fv3io%get_var("slmsk",nlon,nlat_local,r2d4b)
+       this%landmask(:,this%fv3_layout_begin(id):this%fv3_layout_end(id))=r2d4b(:,:)
 
        call fv3io%close
-       deallocate(r2d8b)
+       deallocate(r2d4b)
     enddo
     this%nsoil=nz
     write(6,*) 'slmsk=',maxval(this%landmask),minval(this%landmask)
@@ -604,44 +604,44 @@ if(mype==0) then
 
        call fv3io%open(trim(thisfv3file),'r',200)
 ! 
-       allocate(r2d8b(nlon,nlat_local))
-       call fv3io%get_var("tsfcl",nlon,nlat_local,r2d8b)
+       allocate(r2d4b(nlon,nlat_local))
+       call fv3io%get_var("tsfcl",nlon,nlat_local,r2d4b)
        !-- skin temperature on land
-       this%ges_tsk(:,this%fv3_layout_begin(id):this%fv3_layout_end(id))=r2d8b(:,:)
+       this%ges_tsk(:,this%fv3_layout_begin(id):this%fv3_layout_end(id))=r2d4b(:,:)
 
-       call fv3io%get_var("tsfc",nlon,nlat_local,r2d8b)
+       call fv3io%get_var("tsfc",nlon,nlat_local,r2d4b)
        !-- skin temperature composite
-       this%tsk_comp(:,this%fv3_layout_begin(id):this%fv3_layout_end(id))=r2d8b(:,:)
+       this%tsk_comp(:,this%fv3_layout_begin(id):this%fv3_layout_end(id))=r2d4b(:,:)
 
-       call fv3io%get_var("tsnow_land",nlon,nlat_local,r2d8b)
+       call fv3io%get_var("tsnow_land",nlon,nlat_local,r2d4b)
        !-- snow temperautre on land
-       this%ges_soilt1(:,this%fv3_layout_begin(id):this%fv3_layout_end(id))=r2d8b(:,:)
+       this%ges_soilt1(:,this%fv3_layout_begin(id):this%fv3_layout_end(id))=r2d4b(:,:)
 
-       call fv3io%get_var("qwv_surf_land",nlon,nlat_local,r2d8b)
+       call fv3io%get_var("qwv_surf_land",nlon,nlat_local,r2d4b)
        !-- snow temperautre on land
-       this%ges_qvg(:,this%fv3_layout_begin(id):this%fv3_layout_end(id))=r2d8b(:,:)
+       this%ges_qvg(:,this%fv3_layout_begin(id):this%fv3_layout_end(id))=r2d4b(:,:)
 
-       call fv3io%get_var("clw_surf_land",nlon,nlat_local,r2d8b)
+       call fv3io%get_var("clw_surf_land",nlon,nlat_local,r2d4b)
        !-- snow temperautre on land
-       this%ges_qcg(:,this%fv3_layout_begin(id):this%fv3_layout_end(id))=r2d8b(:,:)
+       this%ges_qcg(:,this%fv3_layout_begin(id):this%fv3_layout_end(id))=r2d4b(:,:)
 
-       call fv3io%get_var("snodl",nlon,nlat_local,r2d8b) 
+       call fv3io%get_var("snodl",nlon,nlat_local,r2d4b) 
        !--  snodl is snow depth on land, units [mm], convert to [m]
-       this%sno(:,this%fv3_layout_begin(id):this%fv3_layout_end(id))=r2d8b(:,:)*1.e-3
+       this%sno(:,this%fv3_layout_begin(id):this%fv3_layout_end(id))=r2d4b(:,:)*1.e-3
 
-       call fv3io%get_var("sncovr",nlon,nlat_local,r2d8b) 
+       call fv3io%get_var("sncovr",nlon,nlat_local,r2d4b) 
        !-- snow cover: 0-1
-       this%sncovr(:,this%fv3_layout_begin(id):this%fv3_layout_end(id))=r2d8b(:,:)
+       this%sncovr(:,this%fv3_layout_begin(id):this%fv3_layout_end(id))=r2d4b(:,:)
 
-       deallocate(r2d8b)
+       deallocate(r2d4b)
 
-       allocate(r3d8b(nlon,nlat_local,nz))
-       call fv3io%get_var("tslb",nlon,nlat_local,nz,r3d8b)
-       this%ges_tslb(:,this%fv3_layout_begin(id):this%fv3_layout_end(id),:)=r3d8b(:,:,:)
-       call fv3io%get_var("smois",nlon,nlat_local,nz,r3d8b)
-       this%ges_smois(:,this%fv3_layout_begin(id):this%fv3_layout_end(id),:)=r3d8b(:,:,:)
+       allocate(r3d4b(nlon,nlat_local,nz))
+       call fv3io%get_var("tslb",nlon,nlat_local,nz,r3d4b)
+       this%ges_tslb(:,this%fv3_layout_begin(id):this%fv3_layout_end(id),:)=r3d4b(:,:,:)
+       call fv3io%get_var("smois",nlon,nlat_local,nz,r3d4b)
+       this%ges_smois(:,this%fv3_layout_begin(id):this%fv3_layout_end(id),:)=r3d4b(:,:,:)
 
-       deallocate(r3d8b)
+       deallocate(r3d4b)
        call fv3io%close
     enddo
     write(6,*) 'this%tsk=',maxval(this%ges_tsk),minval(this%ges_tsk)

--- a/update_gvf/update_GVF.f90
+++ b/update_gvf/update_GVF.f90
@@ -39,7 +39,7 @@ PROGRAM update_GVF
   real, allocatable :: vegfrc_max(:,:)
   real, allocatable :: vegfrc_min(:,:)
   real, allocatable :: field2d(:,:)
-  real(8), allocatable,target :: field2d8b(:,:)
+  real, allocatable,target :: field2d4br(:,:)
 !
 !  for grib2
 !
@@ -105,14 +105,14 @@ if(mype==0) then
     enddo
     call rrfs%get_var("grid_latt",nx,ny,ylat)
     call rrfs%close()
-    allocate(field2d8b(nx,ny))
+    allocate(field2d4br(nx,ny))
     allocate(vegfrc_wrf(nx,ny))
     call rrfs%open("sfc_data.nc","r",200)
-    call rrfs%get_var("vfrac",nx,ny,field2d8b)
-    vegfrc_wrf=field2d8b(:,:)*100.0
+    call rrfs%get_var("vfrac",nx,ny,field2d4br)
+    vegfrc_wrf=field2d4br(:,:)*100.0
 !    call rrfs%get_att("filename",filename_att)
     call rrfs%close()
-    deallocate(field2d8b)
+    deallocate(field2d4br)
 ! get date
   !  read(filename_att(9:21),"(I4,2I2,1x,2I2)") ibkyr,ibkmon,ibkday,ibkhh,ibkmm
   else
@@ -323,16 +323,16 @@ if(mype==0) then
 !
 !
   if(bktype==1) then
-    allocate(field2d8b(nx,ny))
+    allocate(field2d4br(nx,ny))
     call rrfs%open('sfc_data.nc',"w",200)
-    field2d8b=vegfrc*0.01
-    call rrfs%replace_var("vfrac",nx,ny,field2d8b)
-    field2d8b=vegfrc_max*0.01
-    call rrfs%replace_var("shdmax",nx,ny,field2d8b)
-    field2d8b=vegfrc_min*0.01
-    call rrfs%replace_var("shdmin",nx,ny,field2d8b)
+    field2d4br=vegfrc*0.01
+    call rrfs%replace_var("vfrac",nx,ny,field2d4br)
+    field2d4br=vegfrc_max*0.01
+    call rrfs%replace_var("shdmax",nx,ny,field2d4br)
+    field2d4br=vegfrc_min*0.01
+    call rrfs%replace_var("shdmin",nx,ny,field2d4br)
     call rrfs%close()
-    deallocate(field2d8b)
+    deallocate(field2d4br)
   else
     filename='wrf_inout'
     write(*,*) 'open file =',trim(filename)

--- a/update_ice/update_ice.f90
+++ b/update_ice/update_ice.f90
@@ -18,8 +18,7 @@ PROGRAM cycle_ice
   integer :: nx,ny,nz,n,i,j,k
 !
 !  from wrf netcdf 
-  real(8), allocatable,target :: field2d8b(:,:)
-  real(8), allocatable,target :: field3d8b(:,:,:)
+  real(4), allocatable,target :: field2d4br(:,:)
   real(4), allocatable :: field2d(:,:)
   character(len=30) :: varname
 !
@@ -46,7 +45,7 @@ if(mype==0) then
     write(*,*) 'nx_rrfs,ny_rrfs=',nx,ny,nz
     call rrfs%close()
 
-    allocate(field2d8b(nx,ny))
+    allocate(field2d4br(nx,ny))
 
     do n=1,8
        if(n==1) varname='hice' 
@@ -58,11 +57,11 @@ if(mype==0) then
        if(n==7) varname='zorli' 
        if(n==8) varname='zorlw' 
        call rrfs%open('gfsice.sfc_data.nc',"r",200)
-       call rrfs%get_var(trim(varname),nx,ny,field2d8b)
+       call rrfs%get_var(trim(varname),nx,ny,field2d4br)
        call rrfs%close()
 !
        call rrfs%open('sfc_data.nc',"w",200)
-       call rrfs%replace_var(trim(varname),nx,ny,field2d8b)
+       call rrfs%replace_var(trim(varname),nx,ny,field2d4br)
        call rrfs%close()
     enddo
 !

--- a/update_snow/check_imssnow_fv3lam.f90
+++ b/update_snow/check_imssnow_fv3lam.f90
@@ -35,15 +35,15 @@ PROGRAM check_process_imssnow
   integer :: nlon,nlat
   real,allocatable :: xlon(:,:)    !
   real,allocatable :: ylat(:,:)    !
-  real(8),allocatable :: slmsk(:,:)
-  real(8),allocatable :: sncovr(:,:)
-  real(8),allocatable :: snodl(:,:)
-  real(8),allocatable :: snwdph(:,:)
-  real(8),allocatable :: weasdl(:,:)
-  real(8),allocatable :: tsfc(:,:)
-  real(8),allocatable :: tsfcl(:,:)
-  real(8),allocatable :: tsnow_land(:,:)
-  real(8),allocatable :: tslb(:,:,:)
+  real,allocatable :: slmsk(:,:)
+  real,allocatable :: sncovr(:,:)
+  real,allocatable :: snodl(:,:)
+  real,allocatable :: snwdph(:,:)
+  real,allocatable :: weasdl(:,:)
+  real,allocatable :: tsfc(:,:)
+  real,allocatable :: tsfcl(:,:)
+  real,allocatable :: tsnow_land(:,:)
+  real,allocatable :: tslb(:,:,:)
 !
 !
   integer :: num_args

--- a/update_snow/process_imssnow_fv3lam.f90
+++ b/update_snow/process_imssnow_fv3lam.f90
@@ -44,7 +44,8 @@ PROGRAM process_imssnow
   integer,allocatable :: xland(:,:)   !
   real,allocatable :: xlandIMS(:,:)   !
   real,allocatable :: snowice(:,:)    ! snow/ice in RR 
-  real(8),allocatable :: tmp8b(:,:)
+!  real(8),allocatable :: tmp8b(:,:)
+  real,allocatable :: tmp4b(:,:)
 !
 !
   integer :: num_args
@@ -149,12 +150,12 @@ PROGRAM process_imssnow
              thisfv3file='sfc_data.nc'
            endif
            allocate(xland(nlon,nlat))
-           allocate(tmp8b(nlon,nlat))
+           allocate(tmp4b(nlon,nlat))
            call fv3grid%open(trim(thisfv3file),'r',200)
-           call fv3grid%get_var("slmsk",nlon,nlat,tmp8b)
+           call fv3grid%get_var("slmsk",nlon,nlat,tmp4b)
            call fv3grid%close
-           xland=int(tmp8b)
-           deallocate(tmp8b)
+           xland=int(tmp4b)
+           deallocate(tmp4b)
 !
 ! map to grid
 !

--- a/update_snow/update_snow_fv3lam.f90
+++ b/update_snow/update_snow_fv3lam.f90
@@ -54,7 +54,7 @@ subroutine update_snow_fv3lam(snowiceRR,xland,nlon,nlat,id,fv3_io_layout_y)
   character (len=5) :: lutype
   integer(i_kind) :: l, n
   
-  real(8),allocatable :: tmp8b3d(:,:,:),tmp8b2d(:,:)
+!  real(8),allocatable :: tmp8b3d(:,:,:),tmp8b2d(:,:)
   real,allocatable :: tmp4b3d(:,:,:),tmp4b2d(:,:)
 
   character (len=31) :: rmse_var
@@ -197,8 +197,8 @@ subroutine update_snow_fv3lam(snowiceRR,xland,nlon,nlat,id,fv3_io_layout_y)
      stop 1234
   endif
 
-  allocate(tmp8b3d(nlon_regional,nlat_regional,nsig_soil_regional))
-  allocate(tmp8b2d(nlon_regional,nlat_regional))
+  allocate(tmp4b3d(nlon_regional,nlat_regional,nsig_soil_regional))
+  allocate(tmp4b2d(nlon_regional,nlat_regional))
 
   write(6,*)' nlon,lat,sig_regional=',nlon_regional,nlat_regional,nsig_regional
 
@@ -229,82 +229,82 @@ subroutine update_snow_fv3lam(snowiceRR,xland,nlon,nlat,id,fv3_io_layout_y)
   landmask=0
   
 !  rmse_var='T2M' skin temperature on land
-  call fv3grid%get_var("t2m",nlon,nlat,tmp8b2d)
-  surftemp(1:nlon_regional,1:nlat_regional)=tmp8b2d(:,:)
+  call fv3grid%get_var("t2m",nlon,nlat,tmp4b2d)
+  surftemp(1:nlon_regional,1:nlat_regional)=tmp4b2d(:,:)
   write(6,*)' max,min 2-m temp (K)=',maxval(surftemp),minval(surftemp)
 !
 !  rmse_var='TSFCL' skin temperature on land
-  call fv3grid%get_var("tsfcl",nlon,nlat,tmp8b2d)
-  tskin(1:nlon_regional,1:nlat_regional)=tmp8b2d(:,:)
+  call fv3grid%get_var("tsfcl",nlon,nlat,tmp4b2d)
+  tskin(1:nlon_regional,1:nlat_regional)=tmp4b2d(:,:)
   write(6,*)' max,min skin temp (K)=',maxval(tskin),minval(tskin)
 !
 !  rmse_var='TSNOW_LAND' snow temperature on land
-  call fv3grid%get_var("tsnow_land",nlon,nlat,tmp8b2d)
-  tsnow(1:nlon_regional,1:nlat_regional)=tmp8b2d(:,:)
+  call fv3grid%get_var("tsnow_land",nlon,nlat,tmp4b2d)
+  tsnow(1:nlon_regional,1:nlat_regional)=tmp4b2d(:,:)
   write(6,*)' max,min snow temp (K)=',maxval(tsnow),minval(tsnow)
 !
 !  rmse_var='WEASD (SHELEG)' [mm] combined swe
-  call fv3grid%get_var("sheleg",nlon,nlat,tmp8b2d)
-  weasd(1:nlon_regional,1:nlat_regional)=tmp8b2d(:,:)
+  call fv3grid%get_var("sheleg",nlon,nlat,tmp4b2d)
+  weasd(1:nlon_regional,1:nlat_regional)=tmp4b2d(:,:)
   write(6,*)' max,min combined WEASD=',maxval(snow),minval(snow)
 !
 !  rmse_var='SNOW' [mm] swe on land
-  call fv3grid%get_var("weasdl",nlon,nlat,tmp8b2d)
-  snow(1:nlon_regional,1:nlat_regional)=tmp8b2d(:,:)
+  call fv3grid%get_var("weasdl",nlon,nlat,tmp4b2d)
+  snow(1:nlon_regional,1:nlat_regional)=tmp4b2d(:,:)
   write(6,*)' max,min SNOW=',maxval(snow),minval(snow)
 !
 !  rmse_var='WEASDI' [mm] swe on ice
-  call fv3grid%get_var("weasdi",nlon,nlat,tmp8b2d)
-  weasdi(1:nlon_regional,1:nlat_regional)=tmp8b2d(:,:)
+  call fv3grid%get_var("weasdi",nlon,nlat,tmp4b2d)
+  weasdi(1:nlon_regional,1:nlat_regional)=tmp4b2d(:,:)
   write(6,*)' max,min WEASDI=',maxval(weasdi),minval(weasdi)
 !
 !  rmse_var='SNWDPH' [mm] combined snow depth
-  call fv3grid%get_var("snwdph",nlon,nlat,tmp8b2d)
-  snwdph(1:nlon_regional,1:nlat_regional)=tmp8b2d(:,:)*1.e-3 ! convert to [m]
+  call fv3grid%get_var("snwdph",nlon,nlat,tmp4b2d)
+  snwdph(1:nlon_regional,1:nlat_regional)=tmp4b2d(:,:)*1.e-3 ! convert to [m]
   write(6,*)' max,min SNWDPH=',maxval(snwdph),minval(snwdph)
 
 !  rmse_var='SNODL' [mm] snow depth on land
-  call fv3grid%get_var("snodl",nlon,nlat,tmp8b2d)
-  snowh(1:nlon_regional,1:nlat_regional)=tmp8b2d(:,:)*1.e-3 ! convert to [m]
+  call fv3grid%get_var("snodl",nlon,nlat,tmp4b2d)
+  snowh(1:nlon_regional,1:nlat_regional)=tmp4b2d(:,:)*1.e-3 ! convert to [m]
   write(6,*)' max,min SNODL=',maxval(snowh),minval(snowh)
 
 !  rmse_var='SNODI' [mm] snow_depth on ice
-  call fv3grid%get_var("snodi",nlon,nlat,tmp8b2d)
-  snodi(1:nlon_regional,1:nlat_regional)=tmp8b2d(:,:)*1.e-3 ! convert to [m]
+  call fv3grid%get_var("snodi",nlon,nlat,tmp4b2d)
+  snodi(1:nlon_regional,1:nlat_regional)=tmp4b2d(:,:)*1.e-3 ! convert to [m]
   write(6,*)' max,min SNODI=',maxval(snodi),minval(snodi)
 !
 !  rmse_var='SNCOVR' [fraction] combined snow fraction
-  call fv3grid%get_var("sncovr",nlon,nlat,tmp8b2d)
-  snowc(1:nlon_regional,1:nlat_regional)=tmp8b2d(:,:)
+  call fv3grid%get_var("sncovr",nlon,nlat,tmp4b2d)
+  snowc(1:nlon_regional,1:nlat_regional)=tmp4b2d(:,:)
   write(6,*)' max,min SNOWC=',maxval(snowc),minval(snowc)
 !
 !  rmse_var='SNCOVR_ICE' [fraction] snow fraction on ice
-  call fv3grid%get_var("sncovr_ice",nlon,nlat,tmp8b2d)
-  snowc_ice(1:nlon_regional,1:nlat_regional)=tmp8b2d(:,:)
+  call fv3grid%get_var("sncovr_ice",nlon,nlat,tmp4b2d)
+  snowc_ice(1:nlon_regional,1:nlat_regional)=tmp4b2d(:,:)
   write(6,*)' max,min SNOWC_ICE=',maxval(snowc_ice),minval(snowc_ice)
 !
 !  rmse_var='SEAICE' fraction of ice
-  call fv3grid%get_var("fice",nlon,nlat,tmp8b2d)
-  seaice(1:nlon_regional,1:nlat_regional)=tmp8b2d(:,:)
+  call fv3grid%get_var("fice",nlon,nlat,tmp4b2d)
+  seaice(1:nlon_regional,1:nlat_regional)=tmp4b2d(:,:)
   write(6,*)' max,min SEAICE=',maxval(seaice),minval(seaice)
 !
   allocate(soiltemp(1-halo:nlon_regional+halo,1-halo:nlat_regional+halo,nsig_soil_regional))
   allocate(soiltempRRbk(1-halo:nlon_regional+halo,1-halo:nlat_regional+halo,nsig_soil_regional))
 !  rmse_var='TSLB' soil temperature
-  call fv3grid%get_var("tslb",nlon,nlat,nsig_soil_regional,tmp8b3d)
+  call fv3grid%get_var("tslb",nlon,nlat,nsig_soil_regional,tmp4b3d)
   do k=1,nsig_soil_regional
-     soiltemp(1:nlon_regional,1:nlat_regional,k)=tmp8b3d(:,:,k)
+     soiltemp(1:nlon_regional,1:nlat_regional,k)=tmp4b3d(:,:,k)
      write(6,*)' max,min TSLB=',k, maxval(soiltemp(:,:,k)),minval(soiltemp(:,:,k))
   enddo
 !
-  deallocate(tmp8b3d)
+  deallocate(tmp4b3d)
 !
 !  rmse_var='SLMSK' 0 - water, 1 - land, 2 - ice
-  call fv3grid%get_var("slmsk",nlon,nlat,tmp8b2d)
-  landmask(1:nlon_regional,1:nlat_regional)=tmp8b2d
+  call fv3grid%get_var("slmsk",nlon,nlat,tmp4b2d)
+  landmask(1:nlon_regional,1:nlat_regional)=tmp4b2d
   write(6,*)' max,min LANDMASK=',maxval(landmask),minval(landmask)
 !
-  deallocate(tmp8b2d)
+  deallocate(tmp4b2d)
   call fv3grid%close()
 !
 ! fill halo first 
@@ -366,38 +366,38 @@ subroutine update_snow_fv3lam(snowiceRR,xland,nlon,nlat,id,fv3_io_layout_y)
            stop 1234
         endif
 
-        allocate(tmp8b3d(nxlocal,nylocal,nsig_soil_regional))
-        allocate(tmp8b2d(nxlocal,nylocal))
+        allocate(tmp4b3d(nxlocal,nylocal,nsig_soil_regional))
+        allocate(tmp4b2d(nxlocal,nylocal))
 
-        call fv3grid%get_var("tsfcl",nxlocal,nylocal,tmp8b2d)
-        tskin(1:nlon_regional,nlat_regional+1:nlat_regional+halo)=tmp8b2d(:,1:halo)
+        call fv3grid%get_var("tsfcl",nxlocal,nylocal,tmp4b2d)
+        tskin(1:nlon_regional,nlat_regional+1:nlat_regional+halo)=tmp4b2d(:,1:halo)
 !
-        call fv3grid%get_var("tsnow_land",nxlocal,nylocal,tmp8b2d)
-        tsnow(1:nlon_regional,nlat_regional+1:nlat_regional+halo)=tmp8b2d(:,1:halo)
+        call fv3grid%get_var("tsnow_land",nxlocal,nylocal,tmp4b2d)
+        tsnow(1:nlon_regional,nlat_regional+1:nlat_regional+halo)=tmp4b2d(:,1:halo)
 !
-        call fv3grid%get_var("weasdl",nxlocal,nylocal,tmp8b2d)
-        snow(1:nlon_regional,nlat_regional+1:nlat_regional+halo)=tmp8b2d(:,1:halo)
+        call fv3grid%get_var("weasdl",nxlocal,nylocal,tmp4b2d)
+        snow(1:nlon_regional,nlat_regional+1:nlat_regional+halo)=tmp4b2d(:,1:halo)
 !
-        call fv3grid%get_var("snodl",nxlocal,nylocal,tmp8b2d)
-        snowh(1:nlon_regional,nlat_regional+1:nlat_regional+halo)=tmp8b2d(:,1:halo)
+        call fv3grid%get_var("snodl",nxlocal,nylocal,tmp4b2d)
+        snowh(1:nlon_regional,nlat_regional+1:nlat_regional+halo)=tmp4b2d(:,1:halo)
 !
-        call fv3grid%get_var("sncovr",nxlocal,nylocal,tmp8b2d)
-        snowc(1:nlon_regional,nlat_regional+1:nlat_regional+halo)=tmp8b2d(:,1:halo)
+        call fv3grid%get_var("sncovr",nxlocal,nylocal,tmp4b2d)
+        snowc(1:nlon_regional,nlat_regional+1:nlat_regional+halo)=tmp4b2d(:,1:halo)
 !
-        call fv3grid%get_var("fice",nxlocal,nylocal,tmp8b2d)
-        seaice(1:nlon_regional,nlat_regional+1:nlat_regional+halo)=tmp8b2d(:,1:halo)
+        call fv3grid%get_var("fice",nxlocal,nylocal,tmp4b2d)
+        seaice(1:nlon_regional,nlat_regional+1:nlat_regional+halo)=tmp4b2d(:,1:halo)
 !
-        call fv3grid%get_var("tslb",nxlocal,nylocal,nsig_soil_regional,tmp8b3d)
+        call fv3grid%get_var("tslb",nxlocal,nylocal,nsig_soil_regional,tmp4b3d)
         do k=1,nsig_soil_regional
-           soiltemp(1:nlon_regional,nlat_regional+1:nlat_regional+halo,k)=tmp8b3d(:,1:halo,k)
+           soiltemp(1:nlon_regional,nlat_regional+1:nlat_regional+halo,k)=tmp4b3d(:,1:halo,k)
         enddo
 !
-        deallocate(tmp8b3d)
+        deallocate(tmp4b3d)
 !
-        call fv3grid%get_var("slmsk",nxlocal,nylocal,tmp8b2d)
-        landmask(1:nlon_regional,nlat_regional+1:nlat_regional+halo)=tmp8b2d(:,1:halo)
+        call fv3grid%get_var("slmsk",nxlocal,nylocal,tmp4b2d)
+        landmask(1:nlon_regional,nlat_regional+1:nlat_regional+halo)=tmp4b2d(:,1:halo)
 
-        deallocate(tmp8b2d)
+        deallocate(tmp4b2d)
         call fv3grid%close()
      endif
 
@@ -432,38 +432,38 @@ subroutine update_snow_fv3lam(snowiceRR,xland,nlon,nlat,id,fv3_io_layout_y)
            stop 1234
         endif
 
-        allocate(tmp8b3d(nxlocal,nylocal,nsig_soil_regional))
-        allocate(tmp8b2d(nxlocal,nylocal))
+        allocate(tmp4b3d(nxlocal,nylocal,nsig_soil_regional))
+        allocate(tmp4b2d(nxlocal,nylocal))
 
-        call fv3grid%get_var("tsfcl",nxlocal,nylocal,tmp8b2d)
-        tskin(1:nlon_regional,1-halo:0)=tmp8b2d(:,nylocal-halo+1:nylocal)
+        call fv3grid%get_var("tsfcl",nxlocal,nylocal,tmp4b2d)
+        tskin(1:nlon_regional,1-halo:0)=tmp4b2d(:,nylocal-halo+1:nylocal)
 !
-        call fv3grid%get_var("tsnow_land",nxlocal,nylocal,tmp8b2d)
-        tsnow(1:nlon_regional,1-halo:0)=tmp8b2d(:,nylocal-halo+1:nylocal)
+        call fv3grid%get_var("tsnow_land",nxlocal,nylocal,tmp4b2d)
+        tsnow(1:nlon_regional,1-halo:0)=tmp4b2d(:,nylocal-halo+1:nylocal)
 !
-        call fv3grid%get_var("weasdl",nxlocal,nylocal,tmp8b2d)
-        snow(1:nlon_regional,1-halo:0)=tmp8b2d(:,nylocal-halo+1:nylocal)
+        call fv3grid%get_var("weasdl",nxlocal,nylocal,tmp4b2d)
+        snow(1:nlon_regional,1-halo:0)=tmp4b2d(:,nylocal-halo+1:nylocal)
 !
-        call fv3grid%get_var("snodl",nxlocal,nylocal,tmp8b2d)
-        snowh(1:nlon_regional,1-halo:0)=tmp8b2d(:,nylocal-halo+1:nylocal)
+        call fv3grid%get_var("snodl",nxlocal,nylocal,tmp4b2d)
+        snowh(1:nlon_regional,1-halo:0)=tmp4b2d(:,nylocal-halo+1:nylocal)
 !
-        call fv3grid%get_var("sncovr",nxlocal,nylocal,tmp8b2d)
-        snowc(1:nlon_regional,1-halo:0)=tmp8b2d(:,nylocal-halo+1:nylocal)
+        call fv3grid%get_var("sncovr",nxlocal,nylocal,tmp4b2d)
+        snowc(1:nlon_regional,1-halo:0)=tmp4b2d(:,nylocal-halo+1:nylocal)
 !
-        call fv3grid%get_var("fice",nxlocal,nylocal,tmp8b2d)
-        seaice(1:nlon_regional,1-halo:0)=tmp8b2d(:,nylocal-halo+1:nylocal)
+        call fv3grid%get_var("fice",nxlocal,nylocal,tmp4b2d)
+        seaice(1:nlon_regional,1-halo:0)=tmp4b2d(:,nylocal-halo+1:nylocal)
 !
-        call fv3grid%get_var("tslb",nxlocal,nylocal,nsig_soil_regional,tmp8b3d)
+        call fv3grid%get_var("tslb",nxlocal,nylocal,nsig_soil_regional,tmp4b3d)
         do k=1,nsig_soil_regional
-           soiltemp(1:nlon_regional,1-halo:0,k)=tmp8b3d(:,nylocal-halo+1:nylocal,k)
+           soiltemp(1:nlon_regional,1-halo:0,k)=tmp4b3d(:,nylocal-halo+1:nylocal,k)
         enddo
 !
-        deallocate(tmp8b3d)
+        deallocate(tmp4b3d)
 !
-        call fv3grid%get_var("slmsk",nxlocal,nylocal,tmp8b2d)
-        landmask(1:nlon_regional,1-halo:0)=tmp8b2d(:,nylocal-halo+1:nylocal)
+        call fv3grid%get_var("slmsk",nxlocal,nylocal,tmp4b2d)
+        landmask(1:nlon_regional,1-halo:0)=tmp4b2d(:,nylocal-halo+1:nylocal)
 
-        deallocate(tmp8b2d)
+        deallocate(tmp4b2d)
         call fv3grid%close()
      endif
 
@@ -842,102 +842,102 @@ subroutine update_snow_fv3lam(snowiceRR,xland,nlon,nlat,id,fv3_io_layout_y)
      stop 1234
   endif
 
-  allocate(tmp8b3d(nlon_regional,nlat_regional,nsig_soil_regional))
-  allocate(tmp8b2d(nlon_regional,nlat_regional))
+  allocate(tmp4b3d(nlon_regional,nlat_regional,nsig_soil_regional))
+  allocate(tmp4b2d(nlon_regional,nlat_regional))
 
 !  rmse_var='TSLB'
   do k=1,nsig_soil_regional
-     tmp8b3d(:,:,k)=soiltemp(1:nlon_regional,1:nlat_regional,k)
-     write(6,*)' max,min TSLB=',k, maxval(tmp8b3d(:,:,k)),minval(tmp8b3d(:,:,k))
+     tmp4b3d(:,:,k)=soiltemp(1:nlon_regional,1:nlat_regional,k)
+     write(6,*)' max,min TSLB=',k, maxval(tmp4b3d(:,:,k)),minval(tmp4b3d(:,:,k))
   enddo
-  call fv3grid%replace_var("tslb",nlon,nlat,nsig_soil_regional,tmp8b3d)
-  deallocate(tmp8b3d)
+  call fv3grid%replace_var("tslb",nlon,nlat,nsig_soil_regional,tmp4b3d)
+  deallocate(tmp4b3d)
 ! SNCOVR (combined)
-  tmp8b2d=snowc(1:nlon_regional,1:nlat_regional)
+  tmp4b2d=snowc(1:nlon_regional,1:nlat_regional)
   do j=1,nlat_regional
      do i =1,nlon_regional
-        if(tmp8b2d(i,j)<1.0e-10) tmp8b2d(i,j)=0.0_8
+        if(tmp4b2d(i,j)<1.0e-10) tmp4b2d(i,j)=0.0_4
      enddo
   enddo
-  write(6,*)' max,min sncovr=',maxval(tmp8b2d),minval(tmp8b2d)
-  call fv3grid%replace_var("sncovr",nlon,nlat,tmp8b2d)
+  write(6,*)' max,min sncovr=',maxval(tmp4b2d),minval(tmp4b2d)
+  call fv3grid%replace_var("sncovr",nlon,nlat,tmp4b2d)
 ! SNCOVR_ice
-  tmp8b2d=snowc_ice(1:nlon_regional,1:nlat_regional)
+  tmp4b2d=snowc_ice(1:nlon_regional,1:nlat_regional)
   do j=1,nlat_regional
      do i =1,nlon_regional
-        if(tmp8b2d(i,j)<1.0e-10) tmp8b2d(i,j)=0.0_8
+        if(tmp4b2d(i,j)<1.0e-10) tmp4b2d(i,j)=0.0_4
      enddo
   enddo
-  write(6,*)' max,min sncovr_ice=',maxval(tmp8b2d),minval(tmp8b2d)
-  call fv3grid%replace_var("sncovr_ice",nlon,nlat,tmp8b2d)
+  write(6,*)' max,min sncovr_ice=',maxval(tmp4b2d),minval(tmp4b2d)
+  call fv3grid%replace_var("sncovr_ice",nlon,nlat,tmp4b2d)
 ! 'SNODL' on land
-  tmp8b2d=snowh(1:nlon_regional,1:nlat_regional)*1.e3 ! convert to [mm]
+  tmp4b2d=snowh(1:nlon_regional,1:nlat_regional)*1.e3 ! convert to [mm]
   do j=1,nlat_regional
      do i =1,nlon_regional
-        if(tmp8b2d(i,j)<1.0e-10) tmp8b2d(i,j)=0.0_8
+        if(tmp4b2d(i,j)<1.0e-10) tmp4b2d(i,j)=0.0_4
      enddo
   enddo
-  write(6,*)' max,min snodl=',maxval(tmp8b2d),minval(tmp8b2d)
-  call fv3grid%replace_var("snodl",nlon,nlat,tmp8b2d)
+  write(6,*)' max,min snodl=',maxval(tmp4b2d),minval(tmp4b2d)
+  call fv3grid%replace_var("snodl",nlon,nlat,tmp4b2d)
 ! 'SNODI' on ice
-  tmp8b2d=snodi(1:nlon_regional,1:nlat_regional)*1.e3 ! convert to [mm]
+  tmp4b2d=snodi(1:nlon_regional,1:nlat_regional)*1.e3 ! convert to [mm]
   do j=1,nlat_regional
      do i =1,nlon_regional
-        if(tmp8b2d(i,j)<1.0e-10) tmp8b2d(i,j)=0.0_8
+        if(tmp4b2d(i,j)<1.0e-10) tmp4b2d(i,j)=0.0_4
      enddo
   enddo
-  write(6,*)' max,min snodi=',maxval(tmp8b2d),minval(tmp8b2d)
-  call fv3grid%replace_var("snodi",nlon,nlat,tmp8b2d)
+  write(6,*)' max,min snodi=',maxval(tmp4b2d),minval(tmp4b2d)
+  call fv3grid%replace_var("snodi",nlon,nlat,tmp4b2d)
 ! 'SNWDPH' combined
-  tmp8b2d=snwdph(1:nlon_regional,1:nlat_regional)*1.e3 ! convert to [mm]
+  tmp4b2d=snwdph(1:nlon_regional,1:nlat_regional)*1.e3 ! convert to [mm]
   do j=1,nlat_regional
      do i =1,nlon_regional
-        if(tmp8b2d(i,j)<1.0e-10) tmp8b2d(i,j)=0.0_8
+        if(tmp4b2d(i,j)<1.0e-10) tmp4b2d(i,j)=0.0_4
      enddo
   enddo
-  write(6,*)' max,min snowdph=',maxval(tmp8b2d),minval(tmp8b2d)
-  call fv3grid%replace_var("snwdph",nlon,nlat,tmp8b2d)
+  write(6,*)' max,min snowdph=',maxval(tmp4b2d),minval(tmp4b2d)
+  call fv3grid%replace_var("snwdph",nlon,nlat,tmp4b2d)
 ! 'WEASDL' on land
-  tmp8b2d=snow(1:nlon_regional,1:nlat_regional)
+  tmp4b2d=snow(1:nlon_regional,1:nlat_regional)
   do j=1,nlat_regional
      do i =1,nlon_regional
-        if(tmp8b2d(i,j)<1.0e-10) tmp8b2d(i,j)=0.0_8
+        if(tmp4b2d(i,j)<1.0e-10) tmp4b2d(i,j)=0.0_4
      enddo
   enddo
-  write(6,*)' max,min weasdl=',maxval(tmp8b2d),minval(tmp8b2d)
-  call fv3grid%replace_var("weasdl",nlon,nlat,tmp8b2d)
+  write(6,*)' max,min weasdl=',maxval(tmp4b2d),minval(tmp4b2d)
+  call fv3grid%replace_var("weasdl",nlon,nlat,tmp4b2d)
 ! 'WEASDI' on ice
-  tmp8b2d=weasdi(1:nlon_regional,1:nlat_regional)
+  tmp4b2d=weasdi(1:nlon_regional,1:nlat_regional)
   do j=1,nlat_regional
      do i =1,nlon_regional
-        if(tmp8b2d(i,j)<1.0e-10) tmp8b2d(i,j)=0.0_8
+        if(tmp4b2d(i,j)<1.0e-10) tmp4b2d(i,j)=0.0_4
      enddo
   enddo
-  write(6,*)' max,min weasdi=',maxval(tmp8b2d),minval(tmp8b2d)
-  call fv3grid%replace_var("weasdi",nlon,nlat,tmp8b2d)
+  write(6,*)' max,min weasdi=',maxval(tmp4b2d),minval(tmp4b2d)
+  call fv3grid%replace_var("weasdi",nlon,nlat,tmp4b2d)
 ! 'WEASD' combined
-  tmp8b2d=weasd(1:nlon_regional,1:nlat_regional)
+  tmp4b2d=weasd(1:nlon_regional,1:nlat_regional)
   do j=1,nlat_regional
      do i =1,nlon_regional
-        if(tmp8b2d(i,j)<1.0e-10) tmp8b2d(i,j)=0.0_8
+        if(tmp4b2d(i,j)<1.0e-10) tmp4b2d(i,j)=0.0_4
      enddo
   enddo
-  write(6,*)' max,min sheleg=',maxval(tmp8b2d),minval(tmp8b2d)
-  call fv3grid%replace_var("sheleg",nlon,nlat,tmp8b2d)
+  write(6,*)' max,min sheleg=',maxval(tmp4b2d),minval(tmp4b2d)
+  call fv3grid%replace_var("sheleg",nlon,nlat,tmp4b2d)
 ! TSFC
-  tmp8b2d=tskin(1:nlon_regional,1:nlat_regional)
-  write(6,*)' max,min tsfc=',maxval(tmp8b2d),minval(tmp8b2d)
-  call fv3grid%replace_var("tsfc",nlon,nlat,tmp8b2d)
+  tmp4b2d=tskin(1:nlon_regional,1:nlat_regional)
+  write(6,*)' max,min tsfc=',maxval(tmp4b2d),minval(tmp4b2d)
+  call fv3grid%replace_var("tsfc",nlon,nlat,tmp4b2d)
 ! TSFCL
-  tmp8b2d=tskin(1:nlon_regional,1:nlat_regional)
-  write(6,*)' max,min tsfcl=',maxval(tmp8b2d),minval(tmp8b2d)
-  call fv3grid%replace_var("tsfcl",nlon,nlat,tmp8b2d)
+  tmp4b2d=tskin(1:nlon_regional,1:nlat_regional)
+  write(6,*)' max,min tsfcl=',maxval(tmp4b2d),minval(tmp4b2d)
+  call fv3grid%replace_var("tsfcl",nlon,nlat,tmp4b2d)
 ! TSNOW_LAND
-  tmp8b2d=tsnow(1:nlon_regional,1:nlat_regional)
-  write(6,*)' max,min tsnow_land=',maxval(tmp8b2d),minval(tmp8b2d)
-  call fv3grid%replace_var("tsnow_land",nlon,nlat,tmp8b2d)
+  tmp4b2d=tsnow(1:nlon_regional,1:nlat_regional)
+  write(6,*)' max,min tsnow_land=',maxval(tmp4b2d),minval(tmp4b2d)
+  call fv3grid%replace_var("tsnow_land",nlon,nlat,tmp4b2d)
 !
-  deallocate(tmp8b2d)
+  deallocate(tmp4b2d)
   call fv3grid%close()
   
   deallocate(snow)

--- a/use_raphrrr_sfc/module_surface.f90
+++ b/use_raphrrr_sfc/module_surface.f90
@@ -171,8 +171,8 @@ contains
 !
     real(r_single),allocatable,target :: tmp2d4b(:,:)
     real(r_single),allocatable,target :: tmp3d4b(:,:,:)
-    real(r_kind),  allocatable,target :: tmp2d8b(:,:)
-    real(r_kind),  allocatable,target :: tmp3d8b(:,:,:)
+    real(r_single),  allocatable,target :: tmp2d4br(:,:)
+    real(r_single),  allocatable,target :: tmp3d4br(:,:,:)
 !    integer(i_byte),allocatable :: landmask_rrfs(:,:)
 !
     integer  :: nx_rap,ny_rap
@@ -194,8 +194,8 @@ contains
 !
 !    call rrfs%open(trim(rrfsfile),"r",200)
 !    allocate(landmask_rrfs(nx_rrfs,ny_rrfs))
-!    allocate(tmp2d8b(nx_rrfs,ny_rrfs))
-!    call rrfs%get_var("slmsk",nx_rrfs,ny_rrfs,tmp2d8b)
+!    allocate(tmp2d4br(nx_rrfs,ny_rrfs))
+!    call rrfs%get_var("slmsk",nx_rrfs,ny_rrfs,tmp2d4br)
 !    do j=1,ny_rrfs
 !       do i=1,nx_rrfs
 !          ix=this%index_x(i,j)
@@ -203,7 +203,7 @@ contains
 !          if( (ix >= 1 .and. ix <= nx_rap) .and. &
 !              (jx >= 1 .and. jx <= ny_rap) ) then
 !             if(fld2d4b(ix,jx) > 0.025_r_single) then
-!                tmp2d8b(i,j)=2.0_r_kind
+!                tmp2d4br(i,j)=2.0_r_kind
 !             endif
 !          endif
 !        enddo
@@ -211,14 +211,14 @@ contains
 !    call rrfs%close()
 !!
 !    call rrfs%open(trim(rrfsfile),"w",200)
-!    call rrfs%replace_var("slmsk",nx_rrfs,ny_rrfs,tmp2d8b)
+!    call rrfs%replace_var("slmsk",nx_rrfs,ny_rrfs,tmp2d4br)
 !
 !    do j=1,ny_rrfs
 !      do i=1,nx_rrfs
-!         landmask_rrfs(i,j)=int(tmp2d8b(i,j))
+!         landmask_rrfs(i,j)=int(tmp2d4br(i,j))
 !      enddo
 !    enddo
-!    deallocate(tmp2d8b)
+!    deallocate(tmp2d4br)
 !    call rrfs%close()
 !
 !
@@ -233,9 +233,9 @@ contains
           allocate(tmp3d4b(nx_rap,ny_rap,nz_rrfs))
           call raphrrr%get_var(trim(thisvar_rap),nx_rap,ny_rap,nz_rrfs,tmp3d4b)
 
-          allocate(tmp3d8b(nx_rrfs,ny_rrfs,nz_rrfs))
+          allocate(tmp3d4br(nx_rrfs,ny_rrfs,nz_rrfs))
           call rrfs%open(trim(rrfsfile),"r",200)
-          call rrfs%get_var(trim(thisvar_rrfs),nx_rrfs,ny_rrfs,nz_rrfs,tmp3d8b)
+          call rrfs%get_var(trim(thisvar_rrfs),nx_rrfs,ny_rrfs,nz_rrfs,tmp3d4br)
           call rrfs%close()
 
           do j=1,ny_rrfs
@@ -246,11 +246,11 @@ contains
                    (jx >= 1 .and. jx <= ny_rap) ) then
                   if(trim(thisvar_rrfs) == "tslb") then
                      do kx=1,nz_rrfs-1
-                        tmp3d8b(i,j,kx)=tmp3d4b(ix,jx,kx)
+                        tmp3d4br(i,j,kx)=tmp3d4b(ix,jx,kx)
                      enddo
                   else
                      do kx=1,nz_rrfs
-                        tmp3d8b(i,j,kx)=tmp3d4b(ix,jx,kx)
+                        tmp3d4br(i,j,kx)=tmp3d4b(ix,jx,kx)
                      enddo
                   endif
                endif
@@ -259,36 +259,36 @@ contains
           deallocate(tmp3d4b)
 
           call rrfs%open(trim(rrfsfile),"w",200)
-          call rrfs%replace_var(trim(thisvar_rrfs),nx_rrfs,ny_rrfs,nz_rrfs,tmp3d8b)
+          call rrfs%replace_var(trim(thisvar_rrfs),nx_rrfs,ny_rrfs,nz_rrfs,tmp3d4br)
           if(trim(thisvar_rrfs) == "tslb") then
-             call rrfs%replace_var("tiice",nx_rrfs,ny_rrfs,nz_rrfs,tmp3d8b)
+             call rrfs%replace_var("tiice",nx_rrfs,ny_rrfs,nz_rrfs,tmp3d4br)
           elseif(trim(thisvar_rrfs) == "smois") then
              allocate(fld3d4b(nx_rrfs,ny_rrfs,nz_rrfs))
-             fld3d4b=tmp3d8b  ! save for calculating (smois-sh2o)
+             fld3d4b=tmp3d4br  ! save for calculating (smois-sh2o)
           elseif(trim(thisvar_rrfs) == "sh2o") then
-             tmp3d8b=max(0.0,(fld3d4b - tmp3d8b)/0.9)
+             tmp3d4br=max(0.0,(fld3d4b - tmp3d4br)/0.9)
              deallocate(fld3d4b)
-             call rrfs%replace_var("smfr",nx_rrfs,ny_rrfs,nz_rrfs,tmp3d8b)
+             call rrfs%replace_var("smfr",nx_rrfs,ny_rrfs,nz_rrfs,tmp3d4br)
           endif
-          deallocate(tmp3d8b)
+          deallocate(tmp3d4br)
           call rrfs%close()
        else
           allocate(tmp2d4b(nx_rap,ny_rap))
           call raphrrr%get_var(trim(thisvar_rap),nx_rap,ny_rap,tmp2d4b)
 
-          allocate(tmp2d8b(nx_rrfs,ny_rrfs))
+          allocate(tmp2d4br(nx_rrfs,ny_rrfs))
           call rrfs%open(trim(rrfsfile),"r",200)
-          call rrfs%get_var(trim(thisvar_rrfs),nx_rrfs,ny_rrfs,tmp2d8b)
+          call rrfs%get_var(trim(thisvar_rrfs),nx_rrfs,ny_rrfs,tmp2d4br)
           call rrfs%close()
         
-          if(maxval(tmp2d8b) - minval(tmp2d8b) < 1.0e-10) then
+          if(maxval(tmp2d4br) - minval(tmp2d4br) < 1.0e-10) then
             do j=1,ny_rrfs
               do i=1,nx_rrfs
                 ix=this%index_x_nomatch(i,j)
                 jx=this%index_y_nomatch(i,j)
                 if( (ix >= 1 .and. ix <= nx_rap) .and. &
                     (jx >= 1 .and. jx <= ny_rap) ) then
-                  tmp2d8b(i,j)=tmp2d4b(ix,jx)
+                  tmp2d4br(i,j)=tmp2d4b(ix,jx)
                 endif
               enddo
             enddo
@@ -299,7 +299,7 @@ contains
                 jx=this%index_y(i,j)
                 if( (ix >= 1 .and. ix <= nx_rap) .and. &
                     (jx >= 1 .and. jx <= ny_rap) ) then
-                  tmp2d8b(i,j)=tmp2d4b(ix,jx)
+                  tmp2d4br(i,j)=tmp2d4b(ix,jx)
                 endif
               enddo
             enddo
@@ -307,22 +307,22 @@ contains
           deallocate(tmp2d4b)
 
           call rrfs%open(trim(rrfsfile),"w",200)
-          call rrfs%replace_var(trim(thisvar_rrfs),nx_rrfs,ny_rrfs,tmp2d8b)
+          call rrfs%replace_var(trim(thisvar_rrfs),nx_rrfs,ny_rrfs,tmp2d4br)
           if(trim(thisvar_rrfs) == "weasdl") then
-            call rrfs%replace_var("sheleg",nx_rrfs,ny_rrfs,tmp2d8b)
+            call rrfs%replace_var("sheleg",nx_rrfs,ny_rrfs,tmp2d4br)
           elseif(trim(thisvar_rrfs) == "qwv_surf_land") then
-            call rrfs%replace_var("qwv_surf_ice",nx_rrfs,ny_rrfs,tmp2d8b)
+            call rrfs%replace_var("qwv_surf_ice",nx_rrfs,ny_rrfs,tmp2d4br)
           elseif(trim(thisvar_rrfs) == "clw_surf_land") then
-            call rrfs%replace_var("clw_surf_ice",nx_rrfs,ny_rrfs,tmp2d8b)
+            call rrfs%replace_var("clw_surf_ice",nx_rrfs,ny_rrfs,tmp2d4br)
           elseif(trim(thisvar_rrfs) == "tsnow_land") then
-            call rrfs%replace_var("tsnow_ice",nx_rrfs,ny_rrfs,tmp2d8b)
+            call rrfs%replace_var("tsnow_ice",nx_rrfs,ny_rrfs,tmp2d4br)
           elseif(trim(thisvar_rrfs) == "tsfc") then
-            call rrfs%replace_var("tsfcl",nx_rrfs,ny_rrfs,tmp2d8b)
-            call rrfs%replace_var("tsea",nx_rrfs,ny_rrfs,tmp2d8b)
-!            call rrfs%replace_var("tref",nx_rrfs,ny_rrfs,tmp2d8b)
-            call rrfs%replace_var("tisfc",nx_rrfs,ny_rrfs,tmp2d8b)
+            call rrfs%replace_var("tsfcl",nx_rrfs,ny_rrfs,tmp2d4br)
+            call rrfs%replace_var("tsea",nx_rrfs,ny_rrfs,tmp2d4br)
+!            call rrfs%replace_var("tref",nx_rrfs,ny_rrfs,tmp2d4br)
+            call rrfs%replace_var("tisfc",nx_rrfs,ny_rrfs,tmp2d4br)
           endif
-          deallocate(tmp2d8b)
+          deallocate(tmp2d4br)
           call rrfs%close()
 !
 ! for SOILT1 and SNOWC
@@ -333,12 +333,12 @@ contains
 !             allocate(tmp2d4b(nx_rap,ny_rap))
 !             call raphrrr%get_var(trim(thisvar_rap),nx_rap,ny_rap,tmp2d4b)
 !
-!             allocate(tmp2d8b(nx_rrfs,ny_rrfs))
+!             allocate(tmp2d4br(nx_rrfs,ny_rrfs))
 !             call rrfs%open(trim(rrfsfile),"r",200)
-!             call rrfs%get_var(trim(thisvar_rrfs),nx_rrfs,ny_rrfs,tmp2d8b)
+!             call rrfs%get_var(trim(thisvar_rrfs),nx_rrfs,ny_rrfs,tmp2d4br)
 !             call rrfs%close()
 !
-!             if(maxval(tmp2d8b) - minval(tmp2d8b) < 1.0e-10) then
+!             if(maxval(tmp2d4br) - minval(tmp2d4br) < 1.0e-10) then
 !               do j=1,ny_rrfs
 !                 do i=1,nx_rrfs
 !                   ix=this%index_x_nomatch(i,j)
@@ -346,7 +346,7 @@ contains
 !                   if( (ix >= 1 .and. ix <= nx_rap) .and. &
 !                       (jx >= 1 .and. jx <= ny_rap) ) then
 !                      if(fld2d4b(ix,jx) > 0.025) then
-!                        tmp2d8b(i,j)=tmp2d4b(ix,jx)
+!                        tmp2d4br(i,j)=tmp2d4b(ix,jx)
 !                      endif
 !                   endif
 !                 enddo
@@ -359,7 +359,7 @@ contains
 !                    if( (ix >= 1 .and. ix <= nx_rap) .and. &
 !                        (jx >= 1 .and. jx <= ny_rap) ) then
 !                       if(fld2d4b(ix,jx) > 0.025) then
-!                          tmp2d8b(i,j)=tmp2d4b(ix,jx)
+!                          tmp2d4br(i,j)=tmp2d4b(ix,jx)
 !                       endif
 !                    endif
 !                 enddo
@@ -368,8 +368,8 @@ contains
 !             deallocate(tmp2d4b)
 !
 !             call rrfs%open(trim(rrfsfile),"w",200)
-!             call rrfs%replace_var(trim(thisvar_rrfs),nx_rrfs,ny_rrfs,tmp2d8b)
-!             deallocate(tmp2d8b)
+!             call rrfs%replace_var(trim(thisvar_rrfs),nx_rrfs,ny_rrfs,tmp2d4br)
+!             deallocate(tmp2d4br)
 !             call rrfs%close()
 !          endif
 !
@@ -412,7 +412,7 @@ contains
     type(ncio)     :: raphrrr,rrfs
 !
     real(r_single),allocatable,target :: tmp2d4b(:,:)
-    real(r_kind),  allocatable,target :: tmp2d8b(:,:)
+    real(r_single),allocatable,target :: tmp2d4br(:,:)
 !
     integer  :: nx_rap,ny_rap
     integer  :: nx_rrfs,ny_rrfs,nz_rrfs
@@ -427,7 +427,7 @@ contains
     ny_rap=this%nlat_target
 !
     allocate(tmp2d4b(nx_rap,ny_rap))
-    allocate(tmp2d8b(nx_rrfs,ny_rrfs))
+    allocate(tmp2d4br(nx_rrfs,ny_rrfs))
 
     call raphrrr%open(trim(rapfile),"r",200)
     call raphrrr%get_var("SNOW",nx_rap,ny_rap,tmp2d4b)
@@ -440,7 +440,7 @@ contains
        if(nn==4) thisvar_rrfs="snodl"
 
        call rrfs%open(trim(rrfsfile),"r",200)
-       call rrfs%get_var(trim(thisvar_rrfs),nx_rrfs,ny_rrfs,tmp2d8b)
+       call rrfs%get_var(trim(thisvar_rrfs),nx_rrfs,ny_rrfs,tmp2d4br)
        call rrfs%close()
 
        do j=1,ny_rrfs
@@ -450,18 +450,18 @@ contains
              if( (ix >= 1 .and. ix <= nx_rap) .and. &
                  (jx >= 1 .and. jx <= ny_rap) ) then
                 if(tmp2d4b(ix,jx) < 1.0e-10_r_single .and. rlat(i,j) < 37.0 ) then
-                   tmp2d8b(i,j)=0.0_r_kind
+                   tmp2d4br(i,j)=0.0_r_kind
                 endif
              endif
            enddo
        enddo
 
        call rrfs%open(trim(rrfsfile),"w",200)
-       call rrfs%replace_var(trim(thisvar_rrfs),nx_rrfs,ny_rrfs,tmp2d8b)
+       call rrfs%replace_var(trim(thisvar_rrfs),nx_rrfs,ny_rrfs,tmp2d4br)
        call rrfs%close()
 
     end do ! nn
-    deallocate(tmp2d8b)
+    deallocate(tmp2d4br)
     deallocate(tmp2d4b)
   
   end subroutine remove_snow

--- a/use_raphrrr_sfc/use_raphrrr_sfc.f90
+++ b/use_raphrrr_sfc/use_raphrrr_sfc.f90
@@ -36,7 +36,6 @@ program use_raphrrr_sfc
   integer(i_byte),allocatable :: landmask_raphrrr(:,:)
   integer(i_byte),allocatable :: landmask_rrfs(:,:)
   real(r_single),allocatable,target :: tmp2d4b(:,:)
-  real(r_kind),  allocatable,target :: tmp2d8b(:,:)
 
   integer :: i,j,k,n
   character*80 :: raphrrrfile
@@ -76,15 +75,15 @@ program use_raphrrr_sfc
 ! read in rrfs land mask
      call rrfs%open(trim(rrfsfile),"r",200)
      allocate(landmask_rrfs(nx_rrfs,ny_rrfs))
-     allocate(tmp2d8b(nx_rrfs,ny_rrfs))
-     call rrfs%get_var("slmsk",nx_rrfs,ny_rrfs,tmp2d8b)
+     allocate(tmp2d4b(nx_rrfs,ny_rrfs))
+     call rrfs%get_var("slmsk",nx_rrfs,ny_rrfs,tmp2d4b)
      do j=1,ny_rrfs
        do i=1,nx_rrfs
-          landmask_rrfs(i,j)=int(tmp2d8b(i,j))
+          landmask_rrfs(i,j)=int(tmp2d4b(i,j))
           if(landmask_rrfs(i,j) >=2 ) landmask_rrfs(i,j)=1
        enddo
      enddo
-     deallocate(tmp2d8b)
+     deallocate(tmp2d4b)
 
      call rrfs%get_dim("zaxis_1",nz_rrfs)
      call rrfs%close()


### PR DESCRIPTION
When model uses 32-bit CCPP, the variables in the surface and physics restart files are changed from double to float.
This requires to change all arrays that defined as 64-bit in rrfs_utl to 32-bit for surface and physics variables IO. 

This PR will make the changes and the code has been used for summer retro v0.6.2. 