### PR TITLE
Add hydrometeor uncertainty

### DIFF
--- a/cloudanalysis/cloudanalysis_fv3driver.f90
+++ b/cloudanalysis/cloudanalysis_fv3driver.f90
@@ -55,7 +55,7 @@ program cloudanalysis
                                       l_precip_clear_only,l_fog_off,cld_bld_coverage,cld_clr_coverage,&
                                       i_T_Q_adjust,l_saturate_bkCloud,i_precip_vertical_check,l_rtma3d, &
                                       l_qnr_from_qr, n0_rain, &
-                                      r_cloudfrac_threshold
+                                      r_cloudfrac_threshold, i_uncertainty
 
   use namelist_mod, only: load_namelist
   use namelist_mod, only: iyear,imonth,iday,ihour,iminute,isecond
@@ -67,6 +67,9 @@ program cloudanalysis
   use get_fv3sar_bk_mod, only: read_fv3sar_bk,release_mem_fv3sar_bk
   use get_fv3sar_bk_mod, only: ges_ql,ges_qi,ges_qr,ges_qs,ges_qg, &
                                ges_qnr,ges_qni,ges_qnc,ges_qcf
+!  use get_fv3sar_bk_mod, only: unc_ql,unc_qi,unc_qr,unc_qs,unc_qg, &
+!                               unc_qnr,unc_qni,unc_qnc,unc_qcf
+  use get_fv3sar_bk_mod, only: unc_ql,unc_qi,unc_qr,unc_qs,unc_qg
   use get_fv3sar_bk_mod, only: xlon,xlat,xland,soiltbk
   use get_fv3sar_bk_mod, only: read_fv3sar_hydr,release_mem_fv3sar_hydr
   use get_fv3sar_bk_mod, only: read_fv3sar_fix,release_mem_fv3sar_fix
@@ -1293,6 +1296,15 @@ program cloudanalysis
   do k=1,nsig
      do j=1,lat2
         do i=1,lon2
+           if(i_uncertainty) then
+              ! hydrometeor uncertainties
+              unc_ql(i,j,k) = 0.1 * (cldwater_3d(i,j,k) - ges_ql(i,j,k))
+              unc_qi(i,j,k) = 0.1 * (cldice_3d(i,j,k) - ges_qi(i,j,k))
+              unc_qr(i,j,k) = 0.1 * (rain_3d(i,j,k) - ges_qr(i,j,k))
+              unc_qs(i,j,k) = 0.1 * (snow_3d(i,j,k) - ges_qs(i,j,k))
+              unc_qg(i,j,k) = 0.1 * (graupel_3d(i,j,k) - ges_qg(i,j,k))
+!              unc_qnr(i,j,k) = 0.1 * (nrain_3d(i,j,k) - ges_qnr(i,j,k))
+           endif
            ! hydrometeor update
            ges_qr(i,j,k)=rain_3d(i,j,k)
            ges_qs(i,j,k)=snow_3d(i,j,k)
@@ -1302,6 +1314,10 @@ program cloudanalysis
            ges_qnr(i,j,k)=nrain_3d(i,j,k)
            ! cloud number concentration update
            if( l_numconc ) then
+!             if(i_uncertainty) then
+!!              unc_qni(i,j,k) = 0.1 * (nice_3d(i,j,k) - ges_qni(i,j,k))
+!!              unc_qnc(i,j,k) = 0.1 * (nwater_3d(i,j,k) - ges_qnc(i,j,k))
+!             endif 
              ges_qni(i,j,k)=nice_3d(i,j,k)
              ges_qnc(i,j,k)=nwater_3d(i,j,k)
            endif

--- a/cloudanalysis/cloudanalysis_fv3driver.f90
+++ b/cloudanalysis/cloudanalysis_fv3driver.f90
@@ -67,8 +67,6 @@ program cloudanalysis
   use get_fv3sar_bk_mod, only: read_fv3sar_bk,release_mem_fv3sar_bk
   use get_fv3sar_bk_mod, only: ges_ql,ges_qi,ges_qr,ges_qs,ges_qg, &
                                ges_qnr,ges_qni,ges_qnc,ges_qcf
-!  use get_fv3sar_bk_mod, only: unc_ql,unc_qi,unc_qr,unc_qs,unc_qg, &
-!                               unc_qnr,unc_qni,unc_qnc,unc_qcf
   use get_fv3sar_bk_mod, only: unc_ql,unc_qi,unc_qr,unc_qs,unc_qg
   use get_fv3sar_bk_mod, only: xlon,xlat,xland,soiltbk
   use get_fv3sar_bk_mod, only: read_fv3sar_hydr,release_mem_fv3sar_hydr
@@ -1303,7 +1301,6 @@ program cloudanalysis
               unc_qr(i,j,k) = 0.1 * (rain_3d(i,j,k) - ges_qr(i,j,k))
               unc_qs(i,j,k) = 0.1 * (snow_3d(i,j,k) - ges_qs(i,j,k))
               unc_qg(i,j,k) = 0.1 * (graupel_3d(i,j,k) - ges_qg(i,j,k))
-!              unc_qnr(i,j,k) = 0.1 * (nrain_3d(i,j,k) - ges_qnr(i,j,k))
            endif
            ! hydrometeor update
            ges_qr(i,j,k)=rain_3d(i,j,k)
@@ -1314,10 +1311,6 @@ program cloudanalysis
            ges_qnr(i,j,k)=nrain_3d(i,j,k)
            ! cloud number concentration update
            if( l_numconc ) then
-!             if(i_uncertainty) then
-!!              unc_qni(i,j,k) = 0.1 * (nice_3d(i,j,k) - ges_qni(i,j,k))
-!!              unc_qnc(i,j,k) = 0.1 * (nwater_3d(i,j,k) - ges_qnc(i,j,k))
-!             endif 
              ges_qni(i,j,k)=nice_3d(i,j,k)
              ges_qnc(i,j,k)=nwater_3d(i,j,k)
            endif

--- a/cloudanalysis/cloudanalysis_fv3driver.f90
+++ b/cloudanalysis/cloudanalysis_fv3driver.f90
@@ -55,7 +55,7 @@ program cloudanalysis
                                       l_precip_clear_only,l_fog_off,cld_bld_coverage,cld_clr_coverage,&
                                       i_T_Q_adjust,l_saturate_bkCloud,i_precip_vertical_check,l_rtma3d, &
                                       l_qnr_from_qr, n0_rain, &
-                                      r_cloudfrac_threshold, l_uncertainty
+                                      r_cloudfrac_threshold, l_cld_uncertainty
 
   use namelist_mod, only: load_namelist
   use namelist_mod, only: iyear,imonth,iday,ihour,iminute,isecond
@@ -1294,7 +1294,7 @@ program cloudanalysis
   do k=1,nsig
      do j=1,lat2
         do i=1,lon2
-           if(l_uncertainty) then
+           if(l_cld_uncertainty) then
               ! hydrometeor uncertainties
               unc_ql(i,j,k) = 0.1_r_kind * (cldwater_3d(i,j,k) - ges_ql(i,j,k))
               unc_qi(i,j,k) = 0.1_r_kind * (cldice_3d(i,j,k) - ges_qi(i,j,k))

--- a/cloudanalysis/cloudanalysis_fv3driver.f90
+++ b/cloudanalysis/cloudanalysis_fv3driver.f90
@@ -55,7 +55,7 @@ program cloudanalysis
                                       l_precip_clear_only,l_fog_off,cld_bld_coverage,cld_clr_coverage,&
                                       i_T_Q_adjust,l_saturate_bkCloud,i_precip_vertical_check,l_rtma3d, &
                                       l_qnr_from_qr, n0_rain, &
-                                      r_cloudfrac_threshold, i_uncertainty
+                                      r_cloudfrac_threshold, l_uncertainty
 
   use namelist_mod, only: load_namelist
   use namelist_mod, only: iyear,imonth,iday,ihour,iminute,isecond
@@ -1294,13 +1294,13 @@ program cloudanalysis
   do k=1,nsig
      do j=1,lat2
         do i=1,lon2
-           if(i_uncertainty) then
+           if(l_uncertainty) then
               ! hydrometeor uncertainties
-              unc_ql(i,j,k) = 0.1 * (cldwater_3d(i,j,k) - ges_ql(i,j,k))
-              unc_qi(i,j,k) = 0.1 * (cldice_3d(i,j,k) - ges_qi(i,j,k))
-              unc_qr(i,j,k) = 0.1 * (rain_3d(i,j,k) - ges_qr(i,j,k))
-              unc_qs(i,j,k) = 0.1 * (snow_3d(i,j,k) - ges_qs(i,j,k))
-              unc_qg(i,j,k) = 0.1 * (graupel_3d(i,j,k) - ges_qg(i,j,k))
+              unc_ql(i,j,k) = 0.1_r_kind * (cldwater_3d(i,j,k) - ges_ql(i,j,k))
+              unc_qi(i,j,k) = 0.1_r_kind * (cldice_3d(i,j,k) - ges_qi(i,j,k))
+              unc_qr(i,j,k) = 0.1_r_kind * (rain_3d(i,j,k) - ges_qr(i,j,k))
+              unc_qs(i,j,k) = 0.1_r_kind * (snow_3d(i,j,k) - ges_qs(i,j,k))
+              unc_qg(i,j,k) = 0.1_r_kind * (graupel_3d(i,j,k) - ges_qg(i,j,k))
            endif
            ! hydrometeor update
            ges_qr(i,j,k)=rain_3d(i,j,k)

--- a/cloudanalysis/get_fv3sar_bk_mod.f90
+++ b/cloudanalysis/get_fv3sar_bk_mod.f90
@@ -41,7 +41,7 @@ module get_fv3sar_bk_mod
   use mpi_mod, only: npe, mype,mpi_comm_world
   use mpi_mod, only: mpi_finish,mpi_integer,mpi_sum
   use namelist_mod, only: fv3_io_layout_y
-  use rapidrefresh_cldsurf_mod, only: l_uncertainty
+  use rapidrefresh_cldsurf_mod, only: l_cld_uncertainty
 
   implicit none
   private
@@ -181,7 +181,7 @@ contains
         write(gridspec,'(a,I4.4)') 'fv3_grid_spec.',mype
         write(dynvars,'(a,I4.4)') 'fv3_dynvars.',mype
         write(tracers,'(a,I4.4)') 'fv3_tracer.',mype
-        if(l_uncertainty) write(tracers_unc,'(a,I4.4)') 'fv3_tracer_unc.',mype
+        if(l_cld_uncertainty) write(tracers_unc,'(a,I4.4)') 'fv3_tracer_unc.',mype
         write(sfcvars,'(a,I4.4)') 'fv3_sfcdata.',mype
         write(phyvars,'(a,I4.4)') 'fv3_phydata.',mype
         call bg_fv3regfilenameg%init(grid_spec_input=trim(gridspec), &
@@ -197,13 +197,13 @@ contains
 
      dynvars= bg_fv3regfilenameg%dynvars
      tracers= bg_fv3regfilenameg%tracers
-     if(l_uncertainty) tracers_unc= bg_fv3regfilenameg%tracers_unc
+     if(l_cld_uncertainty) tracers_unc= bg_fv3regfilenameg%tracers_unc
      sfcvars= bg_fv3regfilenameg%sfcdata
      phyvars= bg_fv3regfilenameg%phydata
      
      write(6,*) 'dynvars    =',mype,trim(dynvars)
      write(6,*) 'tracers    =',mype,trim(tracers)
-     if(l_uncertainty) write(6,*) 'tracers_unc=',mype,trim(tracers_unc)
+     if(l_cld_uncertainty) write(6,*) 'tracers_unc=',mype,trim(tracers_unc)
      write(6,*) 'sfcvars    =',mype,trim(sfcvars)
      write(6,*) 'phyvars    =',mype,trim(phyvars)
 
@@ -362,7 +362,7 @@ subroutine read_fv3sar_hydr
 !          
      rfv3io_mype=mype
      tracers= bg_fv3regfilenameg%tracers
-     if(l_uncertainty) tracers_unc= bg_fv3regfilenameg%tracers_unc
+     if(l_cld_uncertainty) tracers_unc= bg_fv3regfilenameg%tracers_unc
 
      write(6,*) 'read in hydrometeors==========>', trim(tracers)
 ! 2.1 read in background fields
@@ -430,7 +430,7 @@ subroutine read_fv3sar_hydr
         write(6,*) 'qcf==',k,maxval(ges_qcf(:,:,k)),minval(ges_qcf(:,:,k))
      enddo 
 
-     if(l_uncertainty) then
+     if(l_cld_uncertainty) then
          write(6,*) 'set up hydrometeors uncertainties==========>', trim(tracers_unc)
 !     2.2 set up hydrometeors uncertainties
 !    
@@ -461,7 +461,7 @@ subroutine release_mem_fv3sar_hydr
      if(allocated(ges_qni)) deallocate(ges_qni)
      if(allocated(ges_qnc)) deallocate(ges_qnc)
      if(allocated(ges_qcf)) deallocate(ges_qcf)
-     if(l_uncertainty) then
+     if(l_cld_uncertainty) then
          if(allocated(unc_ql))  deallocate(unc_ql)
          if(allocated(unc_qi))  deallocate(unc_qi)
          if(allocated(unc_qr))  deallocate(unc_qr)
@@ -555,7 +555,7 @@ subroutine update_fv3sar
   integer :: k
 
   tracers    = bg_fv3regfilenameg%tracers
-  if(l_uncertainty) tracers_unc= bg_fv3regfilenameg%tracers_unc
+  if(l_cld_uncertainty) tracers_unc= bg_fv3regfilenameg%tracers_unc
 
   write(6,*) 'write hydrometeors==========>', trim(tracers)
 
@@ -571,7 +571,7 @@ subroutine update_fv3sar
     call gsi_fv3ncdf_write(tracers,'water_nc',ges_qnc,rfv3io_mype)
   endif
 
-  if(l_uncertainty) then
+  if(l_cld_uncertainty) then
     write(6,*) 'write hydrometeor uncertainty==========>', trim(tracers_unc)
     call gsi_fv3ncdf_write(tracers_unc,'liq_wat',unc_ql,rfv3io_mype)
     call gsi_fv3ncdf_write(tracers_unc,'ice_wat',unc_qi,rfv3io_mype)

--- a/cloudanalysis/get_fv3sar_bk_mod.f90
+++ b/cloudanalysis/get_fv3sar_bk_mod.f90
@@ -41,7 +41,7 @@ module get_fv3sar_bk_mod
   use mpi_mod, only: npe, mype,mpi_comm_world
   use mpi_mod, only: mpi_finish,mpi_integer,mpi_sum
   use namelist_mod, only: fv3_io_layout_y
-  use rapidrefresh_cldsurf_mod, only: i_uncertainty
+  use rapidrefresh_cldsurf_mod, only: l_uncertainty
 
   implicit none
   private
@@ -181,7 +181,7 @@ contains
         write(gridspec,'(a,I4.4)') 'fv3_grid_spec.',mype
         write(dynvars,'(a,I4.4)') 'fv3_dynvars.',mype
         write(tracers,'(a,I4.4)') 'fv3_tracer.',mype
-        if(i_uncertainty) write(tracers_unc,'(a,I4.4)') 'fv3_tracer_unc.',mype
+        if(l_uncertainty) write(tracers_unc,'(a,I4.4)') 'fv3_tracer_unc.',mype
         write(sfcvars,'(a,I4.4)') 'fv3_sfcdata.',mype
         write(phyvars,'(a,I4.4)') 'fv3_phydata.',mype
         call bg_fv3regfilenameg%init(grid_spec_input=trim(gridspec), &
@@ -195,15 +195,15 @@ contains
      mype_ql=mype
      mype_2d=mype
 
-     dynvars    = bg_fv3regfilenameg%dynvars
-     tracers    = bg_fv3regfilenameg%tracers
-     if(i_uncertainty) tracers_unc= bg_fv3regfilenameg%tracers_unc
-     sfcvars    = bg_fv3regfilenameg%sfcdata
-     phyvars    = bg_fv3regfilenameg%phydata
+     dynvars= bg_fv3regfilenameg%dynvars
+     tracers= bg_fv3regfilenameg%tracers
+     if(l_uncertainty) tracers_unc= bg_fv3regfilenameg%tracers_unc
+     sfcvars= bg_fv3regfilenameg%sfcdata
+     phyvars= bg_fv3regfilenameg%phydata
      
      write(6,*) 'dynvars    =',mype,trim(dynvars)
      write(6,*) 'tracers    =',mype,trim(tracers)
-     if(i_uncertainty) write(6,*) 'tracers_unc=',mype,trim(tracers_unc)
+     if(l_uncertainty) write(6,*) 'tracers_unc=',mype,trim(tracers_unc)
      write(6,*) 'sfcvars    =',mype,trim(sfcvars)
      write(6,*) 'phyvars    =',mype,trim(phyvars)
 
@@ -362,7 +362,7 @@ subroutine read_fv3sar_hydr
 !          
      rfv3io_mype=mype
      tracers= bg_fv3regfilenameg%tracers
-     if(i_uncertainty) tracers_unc= bg_fv3regfilenameg%tracers_unc
+     if(l_uncertainty) tracers_unc= bg_fv3regfilenameg%tracers_unc
 
      write(6,*) 'read in hydrometeors==========>', trim(tracers)
 ! 2.1 read in background fields
@@ -430,7 +430,7 @@ subroutine read_fv3sar_hydr
         write(6,*) 'qcf==',k,maxval(ges_qcf(:,:,k)),minval(ges_qcf(:,:,k))
      enddo 
 
-     if(i_uncertainty) then
+     if(l_uncertainty) then
          write(6,*) 'set up hydrometeors uncertainties==========>', trim(tracers_unc)
 !     2.2 set up hydrometeors uncertainties
 !    
@@ -461,7 +461,7 @@ subroutine release_mem_fv3sar_hydr
      if(allocated(ges_qni)) deallocate(ges_qni)
      if(allocated(ges_qnc)) deallocate(ges_qnc)
      if(allocated(ges_qcf)) deallocate(ges_qcf)
-     if(i_uncertainty) then
+     if(l_uncertainty) then
          if(allocated(unc_ql))  deallocate(unc_ql)
          if(allocated(unc_qi))  deallocate(unc_qi)
          if(allocated(unc_qr))  deallocate(unc_qr)
@@ -555,7 +555,7 @@ subroutine update_fv3sar
   integer :: k
 
   tracers    = bg_fv3regfilenameg%tracers
-  if(i_uncertainty) tracers_unc= bg_fv3regfilenameg%tracers_unc
+  if(l_uncertainty) tracers_unc= bg_fv3regfilenameg%tracers_unc
 
   write(6,*) 'write hydrometeors==========>', trim(tracers)
 
@@ -571,7 +571,7 @@ subroutine update_fv3sar
     call gsi_fv3ncdf_write(tracers,'water_nc',ges_qnc,rfv3io_mype)
   endif
 
-  if(i_uncertainty) then
+  if(l_uncertainty) then
     write(6,*) 'write hydrometeor uncertainty==========>', trim(tracers_unc)
     call gsi_fv3ncdf_write(tracers_unc,'liq_wat',unc_ql,rfv3io_mype)
     call gsi_fv3ncdf_write(tracers_unc,'ice_wat',unc_qi,rfv3io_mype)

--- a/cloudanalysis/get_fv3sar_bk_mod.f90
+++ b/cloudanalysis/get_fv3sar_bk_mod.f90
@@ -48,7 +48,6 @@ module get_fv3sar_bk_mod
 
   public :: t_bk,h_bk,p_bk,ps_bk,zh,q_bk,pblh
   public :: ges_ql,ges_qi,ges_qr,ges_qs,ges_qg,ges_qnr,ges_qni,ges_qnc,ges_qcf
-!  public :: unc_ql,unc_qi,unc_qr,unc_qs,unc_qg,unc_qnr,unc_qni,unc_qnc,unc_qcf
   public :: unc_ql,unc_qi,unc_qr,unc_qs,unc_qg
   public :: aeta1_ll,pt_ll
   public :: pt_regional
@@ -108,10 +107,6 @@ module get_fv3sar_bk_mod
   real(r_single),allocatable :: unc_qr(:,:,:)  ! rain
   real(r_single),allocatable :: unc_qs(:,:,:)  ! snow
   real(r_single),allocatable :: unc_qg(:,:,:)  ! graupel
-!  real(r_single),allocatable :: unc_qnr(:,:,:) ! rain number concentration
-!  real(r_single),allocatable :: unc_qni(:,:,:) ! cloud ice number concentration
-!  real(r_single),allocatable :: unc_qnc(:,:,:) ! cloud water number concentration
-!  real(r_single),allocatable :: unc_qcf(:,:,:) ! cloud fraction
 
 ! fix files
   real(r_single),allocatable :: xlon(:,:)
@@ -202,7 +197,7 @@ contains
 
      dynvars    = bg_fv3regfilenameg%dynvars
      tracers    = bg_fv3regfilenameg%tracers
-     tracers_unc= bg_fv3regfilenameg%tracers_unc
+     if(i_uncertainty) tracers_unc= bg_fv3regfilenameg%tracers_unc
      sfcvars    = bg_fv3regfilenameg%sfcdata
      phyvars    = bg_fv3regfilenameg%phydata
      
@@ -367,7 +362,7 @@ subroutine read_fv3sar_hydr
 !          
      rfv3io_mype=mype
      tracers= bg_fv3regfilenameg%tracers
-     tracers_unc= bg_fv3regfilenameg%tracers_unc
+     if(i_uncertainty) tracers_unc= bg_fv3regfilenameg%tracers_unc
 
      write(6,*) 'read in hydrometeors==========>', trim(tracers)
 ! 2.1 read in background fields
@@ -449,14 +444,6 @@ subroutine read_fv3sar_hydr
          allocate(unc_qs(nlon_regional,nlat_regional,nsig_regional))
 !        grapel
          allocate(unc_qg(nlon_regional,nlat_regional,nsig_regional))
-!        cloud ice number concentration
-!         allocate(unc_qni(nlon_regional,nlat_regional,nsig_regional))
-!        rain water number concentration
-!         allocate(unc_qnr(nlon_regional,nlat_regional,nsig_regional))
-!        cloud water number concentration
-!         allocate(unc_qnc(nlon_regional,nlat_regional,nsig_regional))
-!        cloud fraction (from phydata file)
-!         allocate(unc_qcf(nlon_regional,nlat_regional,nsig_regional))
      endif
 end subroutine read_fv3sar_hydr
 
@@ -480,10 +467,6 @@ subroutine release_mem_fv3sar_hydr
          if(allocated(unc_qr))  deallocate(unc_qr)
          if(allocated(unc_qs))  deallocate(unc_qs)
          if(allocated(unc_qg))  deallocate(unc_qg)
-!         if(allocated(unc_qnr)) deallocate(unc_qnr)
-!         if(allocated(unc_qni)) deallocate(unc_qni)
-!         if(allocated(unc_qnc)) deallocate(unc_qnc)
-!         if(allocated(unc_qcf)) deallocate(unc_qcf)
      endif
 
 end subroutine release_mem_fv3sar_hydr
@@ -572,7 +555,7 @@ subroutine update_fv3sar
   integer :: k
 
   tracers    = bg_fv3regfilenameg%tracers
-  tracers_unc= bg_fv3regfilenameg%tracers_unc
+  if(i_uncertainty) tracers_unc= bg_fv3regfilenameg%tracers_unc
 
   write(6,*) 'write hydrometeors==========>', trim(tracers)
 
@@ -595,9 +578,6 @@ subroutine update_fv3sar
     call gsi_fv3ncdf_write(tracers_unc,'rainwat',unc_qr,rfv3io_mype)
     call gsi_fv3ncdf_write(tracers_unc,'snowwat',unc_qs,rfv3io_mype)
     call gsi_fv3ncdf_write(tracers_unc,'graupel',unc_qg,rfv3io_mype)
-!    call gsi_fv3ncdf_write(tracers_unc,'rain_nc',unc_qnr,rfv3io_mype)
-!    call gsi_fv3ncdf_write(tracers_unc,'ice_nc',unc_qni,rfv3io_mype)
-!    call gsi_fv3ncdf_write(tracers_unc,'water_nc',unc_qnc,rfv3io_mype)
   endif
 
   call gsi_fv3ncdf_write(tracers,'sphum',q_bk,rfv3io_mype)

--- a/cloudanalysis/module_gsi_rfv3io_tten.f90
+++ b/cloudanalysis/module_gsi_rfv3io_tten.f90
@@ -23,13 +23,14 @@ module gsi_rfv3io_tten_mod
 
 !    directory names (hardwired for now)
   type type_fv3regfilenameg
-      character(len=:),allocatable :: grid_spec !='fv3_grid_spec'            
-      character(len=:),allocatable :: ak_bk     !='fv3_akbk'
-      character(len=:),allocatable :: dynvars   !='fv3_dynvars'
-      character(len=:),allocatable :: tracers   !='fv3_tracer'
-      character(len=:),allocatable :: sfcdata   !='fv3_sfcdata'
-      character(len=:),allocatable :: phydata   !='fv3_phydata'
-      character(len=:),allocatable :: couplerres!='coupler.res'
+      character(len=:),allocatable :: grid_spec     !='fv3_grid_spec'
+      character(len=:),allocatable :: ak_bk         !='fv3_akbk'
+      character(len=:),allocatable :: dynvars       !='fv3_dynvars'
+      character(len=:),allocatable :: tracers       !='fv3_tracer'
+      character(len=:),allocatable :: tracers_unc   !='fv3_tracer_unc'
+      character(len=:),allocatable :: sfcdata       !='fv3_sfcdata'
+      character(len=:),allocatable :: phydata       !='fv3_phydata'
+      character(len=:),allocatable :: couplerres    !='coupler.res'
       contains
       procedure , pass(this):: init=>fv3regfilename_init
   end type type_fv3regfilenameg
@@ -62,12 +63,12 @@ module gsi_rfv3io_tten_mod
 contains
 
   subroutine fv3regfilename_init(this,grid_spec_input,ak_bk_input,dynvars_input,&
-                      tracers_input,sfcdata_input,phydata_input,couplerres_input)
+                      tracers_input,tracers_unc_input,sfcdata_input,phydata_input,couplerres_input)
   implicit None
   class(type_fv3regfilenameg),intent(inout):: this
 
   character(*),optional :: grid_spec_input,ak_bk_input,dynvars_input, &
-                      tracers_input,sfcdata_input,phydata_input,couplerres_input
+                      tracers_input,tracers_unc_input,sfcdata_input,phydata_input,couplerres_input
 
   if(present(grid_spec_input))then
     this%grid_spec=grid_spec_input
@@ -91,6 +92,12 @@ contains
     this%tracers=tracers_input
   else
     this%tracers='fv3_tracer'
+  endif
+
+  if(present(tracers_unc_input))then
+    this%tracers_unc=tracers_unc_input
+  else
+    this%tracers_unc='fv3_tracer_unc'
   endif
 
   if(present(sfcdata_input))then

--- a/cloudanalysis/namelist_mod.f90
+++ b/cloudanalysis/namelist_mod.f90
@@ -44,7 +44,7 @@ module namelist_mod
                             cld_bld_coverage,cld_clr_coverage,&
                             i_cloud_q_innovation,i_ens_mean,DTsTmax,&
                             i_T_Q_adjust,l_saturate_bkCloud,l_rtma3d,i_precip_vertical_check,&
-                            l_qnr_from_qr,n0_rain
+                            l_qnr_from_qr,n0_rain,i_uncertainty
 
 
   implicit none
@@ -71,7 +71,7 @@ module namelist_mod
                                 cld_bld_coverage,cld_clr_coverage,&
                                 i_cloud_q_innovation,i_ens_mean,DTsTmax, &
                                 i_T_Q_adjust,l_saturate_bkCloud,l_rtma3d,i_precip_vertical_check,&
-                                l_qnr_from_qr,n0_rain
+                                l_qnr_from_qr,n0_rain,i_uncertainty
 
     integer :: ios
     integer :: iyear,imonth,iday,ihour,iminute,isecond

--- a/cloudanalysis/namelist_mod.f90
+++ b/cloudanalysis/namelist_mod.f90
@@ -44,7 +44,7 @@ module namelist_mod
                             cld_bld_coverage,cld_clr_coverage,&
                             i_cloud_q_innovation,i_ens_mean,DTsTmax,&
                             i_T_Q_adjust,l_saturate_bkCloud,l_rtma3d,i_precip_vertical_check,&
-                            l_qnr_from_qr,n0_rain,l_uncertainty
+                            l_qnr_from_qr,n0_rain,l_cld_uncertainty
 
 
   implicit none
@@ -71,7 +71,7 @@ module namelist_mod
                                 cld_bld_coverage,cld_clr_coverage,&
                                 i_cloud_q_innovation,i_ens_mean,DTsTmax, &
                                 i_T_Q_adjust,l_saturate_bkCloud,l_rtma3d,i_precip_vertical_check,&
-                                l_qnr_from_qr,n0_rain,l_uncertainty
+                                l_qnr_from_qr,n0_rain,l_cld_uncertainty
 
     integer :: ios
     integer :: iyear,imonth,iday,ihour,iminute,isecond

--- a/cloudanalysis/namelist_mod.f90
+++ b/cloudanalysis/namelist_mod.f90
@@ -44,7 +44,7 @@ module namelist_mod
                             cld_bld_coverage,cld_clr_coverage,&
                             i_cloud_q_innovation,i_ens_mean,DTsTmax,&
                             i_T_Q_adjust,l_saturate_bkCloud,l_rtma3d,i_precip_vertical_check,&
-                            l_qnr_from_qr,n0_rain,i_uncertainty
+                            l_qnr_from_qr,n0_rain,l_uncertainty
 
 
   implicit none
@@ -71,7 +71,7 @@ module namelist_mod
                                 cld_bld_coverage,cld_clr_coverage,&
                                 i_cloud_q_innovation,i_ens_mean,DTsTmax, &
                                 i_T_Q_adjust,l_saturate_bkCloud,l_rtma3d,i_precip_vertical_check,&
-                                l_qnr_from_qr,n0_rain,i_uncertainty
+                                l_qnr_from_qr,n0_rain,l_uncertainty
 
     integer :: ios
     integer :: iyear,imonth,iday,ihour,iminute,isecond

--- a/cloudanalysis/rapidrefresh_cldsurf_mod.f90
+++ b/cloudanalysis/rapidrefresh_cldsurf_mod.f90
@@ -184,7 +184,7 @@ module rapidrefresh_cldsurf_mod
 !      n0_rain         - intercept parameter (m**-4) for raindrop size distribution
 !      r_cloudfrac_threshold  - real, threshold of 1st guess cloud to do cloud building
 !                           = 0.45 default
-!      l_uncertainty   -  flag (logical) to generate file of cloud hydrometeor uncertainty
+!      l_cld_uncertainty   -  flag (logical) to generate file of cloud hydrometeor uncertainty
 !                         .false. = do not generate file (default)
 !
 ! attributes:
@@ -260,7 +260,7 @@ module rapidrefresh_cldsurf_mod
   public :: l_qnr_from_qr
   public :: n0_rain
   public :: r_cloudfrac_threshold
-  public :: l_uncertainty
+  public :: l_cld_uncertainty
 
   logical l_hydrometeor_bkio
   real(r_kind)  dfi_radar_latent_heat_time_period
@@ -322,7 +322,7 @@ module rapidrefresh_cldsurf_mod
   logical              l_qnr_from_qr
   real(r_kind)         n0_rain
   real(r_kind)         r_cloudfrac_threshold
-  logical              l_uncertainty
+  logical              l_cld_uncertainty
 
 contains
 
@@ -434,7 +434,7 @@ contains
     l_qnr_from_qr = .false.
     n0_rain = 100000000.0_r_kind          ! in m**-4; default value assumes smaller drops than in M-P distribution
     r_cloudfrac_threshold = 0.45_r_kind               ! threshold for 1st guess cloud fraction to use cloud building
-    l_uncertainty = .false.                           ! flag to generate hydrometeor uncertainty file (default FALSE)
+    l_cld_uncertainty = .false.                           ! flag to generate hydrometeor uncertainty file (default FALSE)
 
     return
   end subroutine init_rapidrefresh_cldsurf

--- a/cloudanalysis/rapidrefresh_cldsurf_mod.f90
+++ b/cloudanalysis/rapidrefresh_cldsurf_mod.f90
@@ -184,7 +184,7 @@ module rapidrefresh_cldsurf_mod
 !      n0_rain         - intercept parameter (m**-4) for raindrop size distribution
 !      r_cloudfrac_threshold  - real, threshold of 1st guess cloud to do cloud building
 !                           = 0.45 default
-!      i_uncertainty   -  flag (logical) to generate file of cloud hydrometeor uncertainty
+!      l_uncertainty   -  flag (logical) to generate file of cloud hydrometeor uncertainty
 !                         .false. = do not generate file (default)
 !
 ! attributes:
@@ -260,7 +260,7 @@ module rapidrefresh_cldsurf_mod
   public :: l_qnr_from_qr
   public :: n0_rain
   public :: r_cloudfrac_threshold
-  public :: i_uncertainty
+  public :: l_uncertainty
 
   logical l_hydrometeor_bkio
   real(r_kind)  dfi_radar_latent_heat_time_period
@@ -322,7 +322,7 @@ module rapidrefresh_cldsurf_mod
   logical              l_qnr_from_qr
   real(r_kind)         n0_rain
   real(r_kind)         r_cloudfrac_threshold
-  logical              i_uncertainty
+  logical              l_uncertainty
 
 contains
 
@@ -434,7 +434,7 @@ contains
     l_qnr_from_qr = .false.
     n0_rain = 100000000.0_r_kind          ! in m**-4; default value assumes smaller drops than in M-P distribution
     r_cloudfrac_threshold = 0.45_r_kind               ! threshold for 1st guess cloud fraction to use cloud building
-    i_uncertainty = .false.                           ! flag to generate hydrometeor uncertainty file (default FALSE)
+    l_uncertainty = .false.                           ! flag to generate hydrometeor uncertainty file (default FALSE)
 
     return
   end subroutine init_rapidrefresh_cldsurf

--- a/cloudanalysis/rapidrefresh_cldsurf_mod.f90
+++ b/cloudanalysis/rapidrefresh_cldsurf_mod.f90
@@ -184,8 +184,8 @@ module rapidrefresh_cldsurf_mod
 !      n0_rain         - intercept parameter (m**-4) for raindrop size distribution
 !      r_cloudfrac_threshold  - real, threshold of 1st guess cloud to do cloud building
 !                           = 0.45 default
-!      i_uncertainty   -  flag to generate file of cloud hydrometeor uncertainty
-!                         0 = do not generate file (default)
+!      i_uncertainty   -  flag (logical) to generate file of cloud hydrometeor uncertainty
+!                         .false. = do not generate file (default)
 !
 ! attributes:
 !   language: f90
@@ -322,7 +322,7 @@ module rapidrefresh_cldsurf_mod
   logical              l_qnr_from_qr
   real(r_kind)         n0_rain
   real(r_kind)         r_cloudfrac_threshold
-  integer(i_kind)      i_uncertainty
+  logical              i_uncertainty
 
 contains
 
@@ -434,7 +434,7 @@ contains
     l_qnr_from_qr = .false.
     n0_rain = 100000000.0_r_kind          ! in m**-4; default value assumes smaller drops than in M-P distribution
     r_cloudfrac_threshold = 0.45_r_kind               ! threshold for 1st guess cloud fraction to use cloud building
-    i_uncertainty = 0                                 ! flag to generate hydrometeor uncertainty file (default no)
+    i_uncertainty = .false.                           ! flag to generate hydrometeor uncertainty file (default FALSE)
 
     return
   end subroutine init_rapidrefresh_cldsurf

--- a/cloudanalysis/rapidrefresh_cldsurf_mod.f90
+++ b/cloudanalysis/rapidrefresh_cldsurf_mod.f90
@@ -184,6 +184,8 @@ module rapidrefresh_cldsurf_mod
 !      n0_rain         - intercept parameter (m**-4) for raindrop size distribution
 !      r_cloudfrac_threshold  - real, threshold of 1st guess cloud to do cloud building
 !                           = 0.45 default
+!      i_uncertainty   -  flag to generate file of cloud hydrometeor uncertainty
+!                         0 = do not generate file (default)
 !
 ! attributes:
 !   language: f90
@@ -258,6 +260,7 @@ module rapidrefresh_cldsurf_mod
   public :: l_qnr_from_qr
   public :: n0_rain
   public :: r_cloudfrac_threshold
+  public :: i_uncertainty
 
   logical l_hydrometeor_bkio
   real(r_kind)  dfi_radar_latent_heat_time_period
@@ -319,6 +322,7 @@ module rapidrefresh_cldsurf_mod
   logical              l_qnr_from_qr
   real(r_kind)         n0_rain
   real(r_kind)         r_cloudfrac_threshold
+  integer(i_kind)      i_uncertainty
 
 contains
 
@@ -430,6 +434,7 @@ contains
     l_qnr_from_qr = .false.
     n0_rain = 100000000.0_r_kind          ! in m**-4; default value assumes smaller drops than in M-P distribution
     r_cloudfrac_threshold = 0.45_r_kind               ! threshold for 1st guess cloud fraction to use cloud building
+    i_uncertainty = 0                                 ! flag to generate hydrometeor uncertainty file (default no)
 
     return
   end subroutine init_rapidrefresh_cldsurf


### PR DESCRIPTION
### NOTE:  This PR was superseded by an updated version, #49    Closing this branch/PR.

### DESCRIPTION OF CHANGES:
There is a effort between EMC and GSL to include more information about uncertainty for RTMA aviation-related fields. This is an initial set to include hydrometeor uncertainty in the RTMA output.

Specifically, the following changes were made:

- A previous PR in regional_workflow, #558, uses a new flag, i_uncertainty, to turn this step on/off.  If .true., it creates a template netcdf file, copied from the fcst_fv3lam/INPUT/ fv_tracer file, in the same directory.
- Compute "uncertainty" for the hydrometeors, using the simple formula "unc = 0.1 * (A-B)". This can be updated with more sophisticated calculations at a future time.
- Overwrite the field values in the new file with the uncertainties values.

Note that this is part II of a two-part update. The changes to regional_workflow, which add a flag and create the template netcdf file, are in the regional_workflow code/scripts/exregional_nonvarcldanal.sh script, which were included in a separate PR#558. This PR should be merge *after* or with regional_workflow #PR558.

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  This change requires a documentation update

### TESTS CONDUCTED:

- [ ]  hera.intel
- [ ]  orion.intel
- [ ]  cheyenne.intel
- [ ]  cheyenne.gnu
- [ ]  gaea.intel
- [x]  jet.intel
- [ ]  wcoss2.intel
- [ ]  NOAA Cloud (indicate which platform)
- [ ]  Jenkins
- [ ]  fundamental test suite
- [ ]  comprehensive tests (specify which if a subset was used)

### DEPENDENCIES:

This is part II of a two-part update. The changes to regional_workflow, which add a flag and create the template netcdf file, are in the regional_workflow code/scripts/exregional_nonvarcldanal.sh script, which were included in a separate PR#558. This PR should be merge *after* or with regional_workflow #PR558.

### DOCUMENTATION:
None

### ISSUE:
None.

### CHECKLIST

- [ ]  My code follows the style guidelines in the Contributor's Guide
- [x]  I have performed a self-review of my own code using the Code Reviewer's Guide
- [x]  I have commented my code, particularly in hard-to-understand areas
- [ ]  My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ]  My changes do not require updates to the documentation (explain).
- [ ]  My changes generate no new warnings
- [ ]  New and existing tests pass with my changes
- [ ]  Any dependent changes have been merged and published