### PR TITLE
CMakeLists change in bufrsnd codes to allow for proper build on WCOSS2

### DIFF
--- a/bufrsnd/rrfs_bufr.fd/CMakeLists.txt
+++ b/bufrsnd/rrfs_bufr.fd/CMakeLists.txt
@@ -28,11 +28,12 @@ install(
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-#if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
-#  set(CMAKE_Fortran_FLAGS
-#  "-g -traceback -fp-model precise -convert big_endian -assume noold_ldout_format")
-#   set(CMAKE_Fortran_FLAGS_RELEASE "-O2")
-#   set(CMAKE_Fortran_FLAGS_DEBUG "-O0")
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+  set(CMAKE_Fortran_FLAGS
+  "-g -traceback -fp-model precise -assume noold_ldout_format")
+   set(CMAKE_Fortran_FLAGS_RELEASE "-O2")
+   set(CMAKE_Fortran_FLAGS_DEBUG "-O0")
+
 #elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
 #   set(CMAKE_Fortran_FLAGS
 #   "-g -fbacktrace -ffree-form -ffree-line-length-none -fconvert=big-endian")
@@ -41,4 +42,5 @@ install(
 #  if(CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
 #     set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fallow-argument-mismatch")
 #  endif()
-#endif()
+
+endif()

--- a/bufrsnd/rrfs_sndp.fd/CMakeLists.txt
+++ b/bufrsnd/rrfs_sndp.fd/CMakeLists.txt
@@ -29,11 +29,11 @@ install(
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-#if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
-#  set(CMAKE_Fortran_FLAGS
-#  "-g -traceback -fp-model precise -convert big_endian -assume noold_ldout_format")
-#   set(CMAKE_Fortran_FLAGS_RELEASE "-O2")
-#   set(CMAKE_Fortran_FLAGS_DEBUG "-O0")
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+  set(CMAKE_Fortran_FLAGS
+  "-g -traceback -fp-model precise -assume noold_ldout_format")
+   set(CMAKE_Fortran_FLAGS_RELEASE "-O2")
+   set(CMAKE_Fortran_FLAGS_DEBUG "-O0")
 #elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
 #   set(CMAKE_Fortran_FLAGS
 #   "-g -fbacktrace -ffree-form -ffree-line-length-none -fconvert=big-endian")
@@ -42,4 +42,4 @@ install(
 #  if(CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
 #     set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fallow-argument-mismatch")
 #  endif()
-#endif()
+endif()


### PR DESCRIPTION


## DESCRIPTION OF CHANGES:

Restores Intel build options in CMakeLists.txt files for bufr and sndp codes.  These codes are not working properly on WCOSS2 without it.  

## TESTS CONDUCTED:

Tested the rrfs_bufr.exe and rrfs_sndp.exe executables (ones modified by this change) built in my fork within the RRFS_A parallel on WCOSS2.  Confirmed that the BUFR output got generated and looked correct.

This change may require more testing for other applications/platforms - wasn't clear to me why these blocks were commented out in the CMakeLists.txt files.  Also, my original cmake build package (outside of rrfs_utl) didn't have CMakeLists.txt files in the repository, and I don't know enough about cmake builds to know why they should or should not be included.

## DEPENDENCIES:

None

## DOCUMENTATION:

 

## ISSUE (optional):



## CONTRIBUTORS (optional):


