### PR TITLE
Add hydrometeor uncertainty parallel

### DIFF
--- a/cloudanalysis/get_fv3sar_bk_parallel_mod.f90
+++ b/cloudanalysis/get_fv3sar_bk_parallel_mod.f90
@@ -439,12 +439,14 @@ contains
   allocate(ges_qni(lon2,lat2,nsig))   ! cloud ice number concentration
   allocate(ges_qnc(lon2,lat2,nsig))   ! cloud water number concentration
   allocate(ges_qcf(lon2,lat2,nsig))   ! cloud fraction
-! hydrometeor uncertainties
-  allocate(unc_ql(lon2,lat2,nsig))   ! cloud water
-  allocate(unc_qi(lon2,lat2,nsig))   ! cloud ice
-  allocate(unc_qr(lon2,lat2,nsig))   ! rain
-  allocate(unc_qs(lon2,lat2,nsig))   ! snow
-  allocate(unc_qg(lon2,lat2,nsig))   ! graupel
+  if(l_cld_uncertainty) then
+!   hydrometeor uncertainties
+    allocate(unc_ql(lon2,lat2,nsig))   ! cloud water
+    allocate(unc_qi(lon2,lat2,nsig))   ! cloud ice
+    allocate(unc_qr(lon2,lat2,nsig))   ! rain
+    allocate(unc_qs(lon2,lat2,nsig))   ! snow
+    allocate(unc_qg(lon2,lat2,nsig))   ! graupel
+  endif
 !
 ! fix files
   allocate(xlon(lon2,lat2))
@@ -631,12 +633,14 @@ subroutine release_mem_fv3sar
      if(allocated(ges_qnr)) deallocate(ges_qnr)
      if(allocated(ges_qni)) deallocate(ges_qni)
      if(allocated(ges_qnc)) deallocate(ges_qnc)
-     write(6,*) 'core', 1 ,', release memory for hydrometeor uncertainties'
-     if(allocated(unc_ql))  deallocate(unc_ql)
-     if(allocated(unc_qi))  deallocate(unc_qi)
-     if(allocated(unc_qr))  deallocate(unc_qr)
-     if(allocated(unc_qs))  deallocate(unc_qs)
-     if(allocated(unc_qg))  deallocate(unc_qg)
+     if(l_cld_uncertainty) then
+       write(6,*) 'core', 1 ,', release memory for hydrometeor uncertainties'
+       if(allocated(unc_ql))  deallocate(unc_ql)
+       if(allocated(unc_qi))  deallocate(unc_qi)
+       if(allocated(unc_qr))  deallocate(unc_qr)
+       if(allocated(unc_qs))  deallocate(unc_qs)
+       if(allocated(unc_qg))  deallocate(unc_qg)
+     endif
 !
 !  release memory
 !

--- a/cloudanalysis/get_fv3sar_bk_parallel_mod.f90
+++ b/cloudanalysis/get_fv3sar_bk_parallel_mod.f90
@@ -634,7 +634,7 @@ subroutine release_mem_fv3sar
      if(allocated(ges_qni)) deallocate(ges_qni)
      if(allocated(ges_qnc)) deallocate(ges_qnc)
      if(l_cld_uncertainty) then
-       write(6,*) 'core', 1 ,', release memory for hydrometeor uncertainties'
+       write(6,*) 'release memory for hydrometeor uncertainties'
        if(allocated(unc_ql))  deallocate(unc_ql)
        if(allocated(unc_qi))  deallocate(unc_qi)
        if(allocated(unc_qr))  deallocate(unc_qr)

--- a/cloudanalysis/get_fv3sar_bk_parallel_mod.f90
+++ b/cloudanalysis/get_fv3sar_bk_parallel_mod.f90
@@ -806,7 +806,7 @@ subroutine update_fv3sar(mype)
 
   deallocate(d3r4)
 
-!  call general_sub2grid_destroy_info(s)
+  if(.not.l_cld_uncertainty) call general_sub2grid_destroy_info(s)
 
 end subroutine update_fv3sar
 

--- a/cloudanalysis/module_gsi_rfv3io_tten.f90
+++ b/cloudanalysis/module_gsi_rfv3io_tten.f90
@@ -27,6 +27,7 @@ module gsi_rfv3io_tten_mod
       character(len=:),allocatable :: ak_bk     !='fv3_akbk'
       character(len=:),allocatable :: dynvars   !='fv3_dynvars'
       character(len=:),allocatable :: tracers   !='fv3_tracer'
+      character(len=:),allocatable :: tracers_unc   !='fv3_tracer_unc'
       character(len=:),allocatable :: sfcdata   !='fv3_sfcdata'
       character(len=:),allocatable :: phydata   !='fv3_phydata'
       character(len=:),allocatable :: couplerres!='coupler.res'
@@ -62,12 +63,12 @@ module gsi_rfv3io_tten_mod
 contains
 
   subroutine fv3regfilename_init(this,grid_spec_input,ak_bk_input,dynvars_input,&
-                      tracers_input,sfcdata_input,phydata_input,couplerres_input)
+                      tracers_input,tracers_unc_input,sfcdata_input,phydata_input,couplerres_input)
   implicit None
   class(type_fv3regfilenameg),intent(inout):: this
 
   character(*),optional :: grid_spec_input,ak_bk_input,dynvars_input, &
-                      tracers_input,sfcdata_input,phydata_input,couplerres_input
+                      tracers_input,tracers_unc_input,sfcdata_input,phydata_input,couplerres_input
 
   if(present(grid_spec_input))then
     this%grid_spec=grid_spec_input
@@ -91,6 +92,12 @@ contains
     this%tracers=tracers_input
   else
     this%tracers='fv3_tracer'
+  endif
+
+  if(present(tracers_unc_input))then
+    this%tracers_unc=tracers_unc_input
+  else
+    this%tracers_unc='fv3_tracer_unc'
   endif
 
   if(present(sfcdata_input))then

--- a/cloudanalysis/namelist_mod.f90
+++ b/cloudanalysis/namelist_mod.f90
@@ -44,7 +44,7 @@ module namelist_mod
                             cld_bld_coverage,cld_clr_coverage,&
                             i_cloud_q_innovation,i_ens_mean,DTsTmax,&
                             i_T_Q_adjust,l_saturate_bkCloud,l_rtma3d,i_precip_vertical_check,&
-                            l_qnr_from_qr,n0_rain
+                            l_qnr_from_qr,n0_rain,l_cld_uncertainty
 
 
   implicit none
@@ -71,7 +71,7 @@ module namelist_mod
                                 cld_bld_coverage,cld_clr_coverage,&
                                 i_cloud_q_innovation,i_ens_mean,DTsTmax, &
                                 i_T_Q_adjust,l_saturate_bkCloud,l_rtma3d,i_precip_vertical_check,&
-                                l_qnr_from_qr,n0_rain
+                                l_qnr_from_qr,n0_rain,l_cld_uncertainty
 
     integer :: ios
     integer :: iyear,imonth,iday,ihour,iminute,isecond

--- a/cloudanalysis/rapidrefresh_cldsurf_mod.f90
+++ b/cloudanalysis/rapidrefresh_cldsurf_mod.f90
@@ -184,6 +184,8 @@ module rapidrefresh_cldsurf_mod
 !      n0_rain         - intercept parameter (m**-4) for raindrop size distribution
 !      r_cloudfrac_threshold  - real, threshold of 1st guess cloud to do cloud building
 !                           = 0.45 default
+!      l_cld_uncertainty   -  flag (logical) to generate file of cloud hydrometeor uncertainty
+!                         .false. = do not generate file (default)
 !
 ! attributes:
 !   language: f90
@@ -258,6 +260,7 @@ module rapidrefresh_cldsurf_mod
   public :: l_qnr_from_qr
   public :: n0_rain
   public :: r_cloudfrac_threshold
+  public :: l_cld_uncertainty
 
   logical l_hydrometeor_bkio
   real(r_kind)  dfi_radar_latent_heat_time_period
@@ -319,6 +322,7 @@ module rapidrefresh_cldsurf_mod
   logical              l_qnr_from_qr
   real(r_kind)         n0_rain
   real(r_kind)         r_cloudfrac_threshold
+  logical              l_cld_uncertainty
 
 contains
 
@@ -430,6 +434,7 @@ contains
     l_qnr_from_qr = .false.
     n0_rain = 100000000.0_r_kind          ! in m**-4; default value assumes smaller drops than in M-P distribution
     r_cloudfrac_threshold = 0.45_r_kind               ! threshold for 1st guess cloud fraction to use cloud building
+    l_cld_uncertainty = .false.                       ! flag to generate hydrometeor uncertainty file (default FALSE)
 
     return
   end subroutine init_rapidrefresh_cldsurf


### PR DESCRIPTION
**NOTE: This PR replaces a previous PR in rrfs_utl, #41** 

### DESCRIPTION OF CHANGES:
There is a effort between EMC and GSL to include more information about uncertainty for RTMA aviation-related fields. This is an initial set to include hydrometeor uncertainty in the RTMA output.

Specifically, the following changes were made:

- A separate PR in regional_workflow, #558, uses a new flag, l_cld_uncertainty, to turn this step on/off.  If .true., it creates a template netcdf file, copied from the fcst_fv3lam/INPUT/ fv_tracer file, in the same directory.
- Compute "uncertainty" for the hydrometeors, using the simple formula "unc = 0.1 * (A-B)". This can be updated with more sophisticated calculations at a future time.
- Overwrite the hydrometeor field values in the new file with the uncertainties values.

Note that this is part II of a two-part update. The changes to regional_workflow, which add a flag and create the template netcdf file, are in the regional_workflow code/scripts/exregional_nonvarcldanal.sh script, which were included in a separate PR#580. This PR should be merge with regional_workflow #PR580.

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  This change requires a documentation update

### TESTS CONDUCTED:

- [ ]  hera.intel
- [ ]  orion.intel
- [ ]  cheyenne.intel
- [ ]  cheyenne.gnu
- [ ]  gaea.intel
- [x]  jet.intel
- [ ]  wcoss2.intel
- [ ]  NOAA Cloud (indicate which platform)
- [ ]  Jenkins
- [ ]  fundamental test suite
- [ ]  comprehensive tests (specify which if a subset was used)

### DEPENDENCIES:

This is part II of a two-part update. The changes to regional_workflow, which add a flag and create the template netcdf file, are in the regional_workflow code/scripts/exregional_nonvarcldanal.sh script, which were included in a separate PR#558. This PR should be merge *after* or with regional_workflow #PR558.

### DOCUMENTATION:
None

### ISSUE:
None.

### CHECKLIST

- [ ]  My code follows the style guidelines in the Contributor's Guide
- [x]  I have performed a self-review of my own code using the Code Reviewer's Guide
- [x]  I have commented my code, particularly in hard-to-understand areas
- [ ]  My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ]  My changes do not require updates to the documentation (explain).
- [ ]  My changes generate no new warnings
- [ ]  New and existing tests pass with my changes
- [ ]  Any dependent changes have been merged and published