### PR TITLE
Fix blending *.so files install location

### DIFF
--- a/blending/chgres_winds/CMakeLists.txt
+++ b/blending/chgres_winds/CMakeLists.txt
@@ -14,4 +14,4 @@ execute_process(
 
 #install chgres_winds.so
 file(GLOB_RECURSE SOFILE "${CMAKE_CURRENT_BINARY_DIR}/*chgres_winds*.so")
-install(FILES ${SOFILE} DESTINATION ${CMAKE_INSTALL_LIBDIR} RENAME chgres_winds.so)
+install(FILES ${SOFILE} DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME chgres_winds.so)

--- a/blending/raymond/CMakeLists.txt
+++ b/blending/raymond/CMakeLists.txt
@@ -12,4 +12,4 @@ execute_process(
 
 #install raymond.so
 file(GLOB_RECURSE SOFILE "${CMAKE_CURRENT_BINARY_DIR}/*raymond*.so")
-install(FILES ${SOFILE} DESTINATION ${CMAKE_INSTALL_LIBDIR} RENAME raymond.so)
+install(FILES ${SOFILE} DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME raymond.so)

--- a/blending/remap_dwinds/CMakeLists.txt
+++ b/blending/remap_dwinds/CMakeLists.txt
@@ -14,4 +14,4 @@ execute_process(
 
 #install remap_dwinds.so
 file(GLOB_RECURSE SOFILE "${CMAKE_CURRENT_BINARY_DIR}/*remap_dwinds*.so")
-install(FILES ${SOFILE} DESTINATION ${CMAKE_INSTALL_LIBDIR} RENAME remap_dwinds.so)
+install(FILES ${SOFILE} DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME remap_dwinds.so)

--- a/blending/remap_scalar/CMakeLists.txt
+++ b/blending/remap_scalar/CMakeLists.txt
@@ -14,4 +14,4 @@ execute_process(
 
 #install remap_scalar.so
 file(GLOB_RECURSE SOFILE "${CMAKE_CURRENT_BINARY_DIR}/*remap_scalar*.so")
-install(FILES ${SOFILE} DESTINATION ${CMAKE_INSTALL_LIBDIR} RENAME remap_scalar.so)
+install(FILES ${SOFILE} DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME remap_scalar.so)


### PR DESCRIPTION
## DESCRIPTION OF CHANGES:

Change install location of the blending *.so files from ufs-srweather-app/lib64 to ufs-srweather-app/bin.

## TESTS CONDUCTED:

Tested rrfs_utl build using ufs-srweather-app devbuild.sh