### PR TITLE
Need to add "mgbf" lib as dependence for using RRFS release branch.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ find_package(wrf_io REQUIRED)
 
 # Other dependencies
 find_package(ncdiag REQUIRED)
+find_package(mgbf REQUIRED)
 find_package(gsi REQUIRED)
 
 add_subdirectory(baselib/regional_esg_grid.fd)


### PR DESCRIPTION
This is required because GSI just added mgbf lib as a dependance.
Tested on Hera with retro runs.