### PR TITLE
remove the warning information in compiling pre-blending code.

### DIFF
--- a/blending.fd/CMakeLists.txt
+++ b/blending.fd/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 project(blending)
 
-add_subdirectory(chgres_winds)
+#add_subdirectory(chgres_winds)
 add_subdirectory(raymond)
-add_subdirectory(remap_dwinds)
-add_subdirectory(remap_scalar)
+#add_subdirectory(remap_dwinds)
+#add_subdirectory(remap_scalar)

--- a/pre_blending.fd/CMakeLists.txt
+++ b/pre_blending.fd/CMakeLists.txt
@@ -10,10 +10,9 @@ list(APPEND src_pre_blending
 find_library(LIBIOMP5_PATH NAMES libiomp5.so)
 
 if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
-  set(CMAKE_Fortran_FLAGS
-  "-fp-model precise --f90flags='-fopenmp' -L${LIBIOMP5_PATH} -liomp5")
-   set(CMAKE_Fortran_FLAGS_RELEASE "-O2 --f90flags='-fopenmp' -L${LIBIOMP5_PATH} -liomp5")
-   set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -g -traceback -fp-model precise --f90flags='-fopenmp' -L${LIBIOMP5_PATH} -liomp5")
+   set(CMAKE_Fortran_FLAGS "-fp-model precise -L${LIBIOMP5_PATH} -liomp5")
+   set(CMAKE_Fortran_FLAGS_RELEASE "-O2 -L${LIBIOMP5_PATH} -liomp5")
+   set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -g -traceback -fp-model precise -L${LIBIOMP5_PATH} -liomp5")
 endif()
 
 add_executable(fv3lam_pre_blending.exe ${src_pre_blending})


### PR DESCRIPTION
1. Comment out the pre-blending libraries in blending directory 
    because they are now in fortran version pre-blending directory.
3. Remove unused compiler options in pre-blending.


