### PR TITLE
fix dpt2m compiling issue after wgrib2 library updates on wcoss2

### DIFF
--- a/dpt2m_post.fd/CMakeLists.txt
+++ b/dpt2m_post.fd/CMakeLists.txt
@@ -1,8 +1,41 @@
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -mkl")
+set(CMAKE_EXE_LINKER_FLAGS "-mkl")
+
+#set(CMAKE_Fortran_FLAGS "-O3 -fp-model precise -fpe0 -mkl" CACHE STRING "" FORCE)
+#set(CMAKE_EXE_LINKER_FLAGS "-mkl" CACHE STRING "" FORCE)
+
+message(STATUS "CHECK: Fortran Flags: ${CMAKE_Fortran_FLAGS}")
+message(STATUS "CHECK: Release Flags: ${CMAKE_Fortran_FLAGS_RELEASE}")
+message(STATUS "CHECK: Production Flags: ${CMAKE_Fortran_FLAGS_PRODUCTION}")
+message(STATUS "CHECK: Linker Flags: ${CMAKE_EXE_LINKER_FLAGS}")
+
 list(APPEND src_dpt2m_post
   dpt2m_post.f90)
 
+include_directories(
+    $ENV{WGRIB2_INC}
+    $ENV{NETCDF_INCLUDES}
+    $ENV{IP_INC4}
+)
+
 add_executable(dpt2m_post.exe ${src_dpt2m_post})
-target_link_libraries(dpt2m_post.exe PRIVATE wgrib2::wgrib2)
+
+target_link_libraries(dpt2m_post.exe
+    PRIVATE
+    $ENV{WGRIB2_LIBDIR}/libwgrib2_ftn_api.a
+    $ENV{WGRIB2_LIBDIR}/libwgrib2.a
+    $ENV{IP_LIB4}
+    $ENV{G2C_LIB}
+    $ENV{SP_LIB4}
+    $ENV{W3EMC_LIB4}
+    -L$ENV{NETCDF_LIBRARIES}
+    netcdff
+    netcdf
+    $ENV{LIBAEC_LIB}
+    jasper
+    png
+    z
+)
 
 install(
   TARGETS dpt2m_post.exe
@@ -10,4 +43,3 @@ install(
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-


### PR DESCRIPTION


## DESCRIPTION OF CHANGES:

fix dpt2m compiling issue after wgrib2 library updates on wcoss2

## TESTS CONDUCTED:

Explicitly state what tests were run on these changes, or if
any are still pending (for README or other text-only changes, just put "None
required". Make note of the compilers used, the platform/machine, and other
relevant details as necessary. For more complicated changes, or those resulting
in scientific changes, please be explicit!

## DEPENDENCIES:

Add any links to external PRs (e.g. regional_workflow and/or UFS PRs). For
example:
- NOAA-EMC/GSI/pull/<pr_number>

## DOCUMENTATION:

If this PR is contributing new capabilities that need to be documented, please
also include updates to the existing documentation as part of this PR.

## ISSUE (optional):

If this PR is resolving or referencing one or more issues, in this repository or
elewhere, list them here. For example, "Fixes issue mentioned in #123" or
"Related to bug in https://github.com/ufs-community/other_repository/pull/63"

## CONTRIBUTORS (optional):

If others have contributed to this work aside from the PR author, list them here

