### PR TITLE
Use ip_d intead of ip_4 for snow trim.

### DIFF
--- a/update_snow.fd/CMakeLists.txt
+++ b/update_snow.fd/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(process_imssnow_fv3lam.exe PRIVATE ${PROJECT_NAME}::ncio
                                                  PRIVATE g2::g2_4
                                                  PRIVATE g2tmpl::g2tmpl
                                                  PRIVATE bacio::bacio_4
-                                                 PRIVATE ip::ip_4
+                                                 PRIVATE ip::ip_d
                                                  PRIVATE sp::sp_4
                                                  PRIVATE MPI::MPI_Fortran)
 

--- a/update_snow.fd/module_imssnow.f90
+++ b/update_snow.fd/module_imssnow.f90
@@ -256,7 +256,8 @@ contains
     REAL :: XPNMC8,YPNMC8,ENNMC8,ALNMC8,ORIENT8
     REAL :: XPNMCAF,YPNMCAF,ENNMCAF,ALNMCAF,ORIENTAF
 
-    real :: YYLAT(1),XLONG(1), RM, RAD, XX(1),YY(1),X, Y
+    real :: RM, RAD, X, Y
+    real(8) :: YYLAT(1),XLONG(1),XX(1),YY(1)
     integer :: IS,IP1,JS,JP1, IPOINT, JPOINT
 !
     integer :: iland,KOUNT
@@ -266,7 +267,7 @@ contains
 !
     integer                   :: nret,nout
     real                      :: dum
-    real, parameter           :: undefined_value = -1.0
+    real(8), parameter           :: undefined_value = -1.0
 
 !
     kgds_src=this%kgds


### PR DESCRIPTION
This is to fix the compiling error when the use of the updated GSI system within RRFSv1.

The head file (include file) for the IP library has changed from ip_4 to ip_d. This update requires the following modifications:

1. Code Change: In the module_imssnow.f90 file (located in update_snow.fd), the parameter definition in the gdswzd subroutine must be updated from 4 bytes to 8 bytes for float variables.
2. Library Linking: The linking IP library needs to be updated from ip_4 to ip_d.

Tests Conducted:
These changes resolve the current compiling errors. Please note that testing indicates a few data points differ between the new and old code. This is expected and considered a reasonable outcome, as the accuracy of the location calculation in gdswzd has been updated.