### PR TITLE
[production/RRFS.1] Makes the first broken out station BUFR output bit identical on rerun

### DIFF
--- a/bufrsnd.fd/rrfs_stnmlist.fd/stnmlist.f
+++ b/bufrsnd.fd/rrfs_stnmlist.fd/stnmlist.f
@@ -72,6 +72,7 @@ C$$$
       CHARACTER*80  FMTO,TSTR
       CHARACTER*8   SUBSET
       REAL*8	    TAB(MXTS,MXTB)
+      INTEGER::     JDATE_INIT
       DIMENSION     LIST(MXLS)
       LOGICAL       ONLIST
 
@@ -90,6 +91,7 @@ C-----------------------------------------------------------------------
       READ (5,'(I1)') IOTYPE
       READ (5,'(A)') BFRFIL
       READ (5,'(A)') DIRD
+      READ (5, '(I10)') JDATE_INIT
       LSS = LEN(DIRD)
       DO WHILE(DIRD(LSS:LSS).EQ.' ')
 	 LSS = LSS - 1
@@ -149,7 +151,7 @@ C  -----------------------------------------------------------------
 
 C  COPY OFF STATIONS ON THE LIST INTO THEIR OWN FILES
 C  --------------------------------------------------
-      JDATE=0
+      JDATE=JDATE_INIT
       DO N=1,NTAB
          IF(TAB(1,N).GE.BMISS) CYCLE
          print *, 'IDNM, IREC, ISUB: ',TAB(1,N),TAB(2,N),TAB(3,N)

--- a/bufrsnd.fd/rrfs_stnmlist.fd/stnmlist.f
+++ b/bufrsnd.fd/rrfs_stnmlist.fd/stnmlist.f
@@ -149,7 +149,7 @@ C  -----------------------------------------------------------------
 
 C  COPY OFF STATIONS ON THE LIST INTO THEIR OWN FILES
 C  --------------------------------------------------
-
+      JDATE=0
       DO N=1,NTAB
          IF(TAB(1,N).GE.BMISS) CYCLE
          print *, 'IDNM, IREC, ISUB: ',TAB(1,N),TAB(2,N),TAB(3,N)


### PR DESCRIPTION

## DESCRIPTION OF CHANGES:

The first call to UFBPOS seemed to return random garbage for JDATE on the first call, so passing in a proper initial JDATE value as a fourth argument so the first call is consistent and seemingly correct.    

## TESTS CONDUCTED:

Made repeated runs of the stnmlist code on RRFS BUFR output, and confirmed that that 000001 station was identical in each.  Confirmed with the latest change that the first station could be ingested into GEMPAK.

## DEPENDENCIES:


## DOCUMENTATION:


